### PR TITLE
Update for new SHACL file format

### DIFF
--- a/src/main/java/org/spdx/tools/model2java/ConstraintCollector.java
+++ b/src/main/java/org/spdx/tools/model2java/ConstraintCollector.java
@@ -52,6 +52,7 @@ class ConstraintCollector implements ConstraintVisitor {
 	private Integer strMaxLenght = null;
 	private Node expectedClass = null;
 	private SparqlConstraint sparqlConstraint = null;
+	private ShNot notConstraint;
 	
 
 	@Override
@@ -147,8 +148,7 @@ class ConstraintCollector implements ConstraintVisitor {
 
 	@Override
 	public void visit(ShNot constraint) {
-		// ignore
-		
+		this.notConstraint = constraint;
 	}
 
 	@Override
@@ -276,5 +276,12 @@ class ConstraintCollector implements ConstraintVisitor {
 	 */
 	public SparqlConstraint getSparqlConstraint() {
 		return sparqlConstraint;
+	}
+
+	/**
+	 * @return the notConstraint
+	 */
+	public ShNot getNotConstraint() {
+		return notConstraint;
 	}
 }

--- a/src/main/java/org/spdx/tools/model2java/ShaclToJava.java
+++ b/src/main/java/org/spdx/tools/model2java/ShaclToJava.java
@@ -812,16 +812,12 @@ public class ShaclToJava {
 		for (Resource individual:objectIndividuals) {
 			boolean hasLabel = false;
 			String individualClassUri = null;
-			String rangeUri = null;
 			StmtIterator propertyIter = individual.listProperties();
 			for ( ; propertyIter.hasNext() ; ) {
 				Statement stmt = propertyIter.next();
 				if (stmt.getPredicate().getURI().equals(ShaclToJavaConstants.TYPE_PRED) && stmt.getObject().isURIResource() &&
 						!stmt.getObject().asResource().getURI().equals(ShaclToJavaConstants.NAMED_INDIVIDUAL)) {
 					individualClassUri = stmt.getObject().asResource().getURI();
-				}
-				if (stmt.getPredicate().getURI().equals(ShaclToJavaConstants.RANGE_URI) && stmt.getObject().isURIResource()) {
-					rangeUri = stmt.getObject().asResource().getURI();
 				}
 				if (stmt.getPredicate().getURI().equals(ShaclToJavaConstants.LABEL_URI)) {
 					hasLabel = true;
@@ -830,11 +826,11 @@ public class ShaclToJava {
 			if (hasLabel && Objects.nonNull(individualClassUri)) {
 				// TODO: This is a bit of a hack, maybe there is a better way to see if this is a class
 				this.enumClassUris.add(individualClassUri);
-			} else if (Objects.nonNull(rangeUri)) {
-				List<String> individualsForRange = classUriToIndividualUris.get(rangeUri);
+			} else {
+				List<String> individualsForRange = classUriToIndividualUris.get(individualClassUri);
 				if (Objects.isNull(individualsForRange)) {
 					individualsForRange = new ArrayList<>();
-					classUriToIndividualUris.put(rangeUri, individualsForRange);
+					classUriToIndividualUris.put(individualClassUri, individualsForRange);
 				}
 				individualsForRange.add(individual.getURI());
 			}

--- a/testResources/spdx-model.ttl
+++ b/testResources/spdx-model.ttl
@@ -1,11 +1,10 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://spdx.org/rdf/3.0.1/terms/Core/> .
-@prefix ns2: <https://spdx.org/rdf/3.0.1/terms/Security/> .
-@prefix ns3: <https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/> .
+@prefix ns1: <https://spdx.org/rdf/3.0.1/terms/Software/> .
+@prefix ns2: <https://spdx.org/rdf/3.0.1/terms/Core/> .
+@prefix ns3: <https://spdx.org/rdf/3.0.1/terms/Security/> .
 @prefix ns4: <https://spdx.org/rdf/3.0.1/terms/Dataset/> .
-@prefix ns5: <https://spdx.org/rdf/3.0.1/terms/Software/> .
-@prefix ns6: <https://spdx.org/rdf/3.0.1/terms/AI/> .
-@prefix ns7: <http://spdx.invalid./> .
+@prefix ns5: <https://spdx.org/rdf/3.0.1/terms/AI/> .
+@prefix ns6: <https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/> .
 @prefix omg-ann: <https://www.omg.org/spec/Commons/AnnotationVocabulary/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -14,254 +13,264 @@
 @prefix spdx: <https://spdx.org/rdf/3.0.1/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-ns6:AIPackage a owl:Class,
+ns5:AIPackage a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Specifies an AI package and its associated information."@en ;
-    rdfs:subClassOf ns5:Package ;
+    rdfs:subClassOf ns1:Package ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:PresenceType ;
+    sh:property [ sh:class ns2:PresenceType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/yes> <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/no> <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/noAssertion> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns6:useSensitivePersonalInformation ],
-        [ sh:class ns6:EnergyConsumption ;
+            sh:path ns5:autonomyType ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns5:modelExplainability ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns5:modelDataPreprocessing ],
+        [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns6:energyConsumption ],
-        [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:path ns6:standardCompliance ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns6:modelDataPreprocessing ],
-        [ sh:class ns1:DictionaryEntry ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns6:metric ],
-        [ sh:class ns6:SafetyRiskAssessmentType ;
+            sh:path ns5:informationAboutTraining ],
+        [ sh:class ns5:SafetyRiskAssessmentType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/AI/SafetyRiskAssessmentType/serious> <https://spdx.org/rdf/3.0.1/terms/AI/SafetyRiskAssessmentType/high> <https://spdx.org/rdf/3.0.1/terms/AI/SafetyRiskAssessmentType/medium> <https://spdx.org/rdf/3.0.1/terms/AI/SafetyRiskAssessmentType/low> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns6:safetyRiskAssessment ],
-        [ sh:class ns1:DictionaryEntry ;
+            sh:path ns5:safetyRiskAssessment ],
+        [ sh:class ns2:DictionaryEntry ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns6:metricDecisionThreshold ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns6:typeOfModel ],
-        [ sh:class ns1:DictionaryEntry ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns6:hyperparameter ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns6:domain ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns6:modelExplainability ],
+            sh:path ns5:metricDecisionThreshold ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns6:informationAboutApplication ],
+            sh:path ns5:informationAboutApplication ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns5:standardCompliance ],
+        [ sh:class ns2:DictionaryEntry ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns5:metric ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns6:limitation ],
-        [ sh:class ns1:PresenceType ;
+            sh:path ns5:limitation ],
+        [ sh:class ns2:DictionaryEntry ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns5:hyperparameter ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns5:domain ],
+        [ sh:class ns2:PresenceType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/yes> <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/no> <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/noAssertion> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns6:autonomyType ],
-        [ sh:datatype xsd:string ;
+            sh:path ns5:useSensitivePersonalInformation ],
+        [ sh:class ns5:EnergyConsumption ;
             sh:maxCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns5:energyConsumption ],
+        [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:path ns6:informationAboutTraining ] .
+            sh:path ns5:typeOfModel ] .
 
 <https://spdx.org/rdf/3.0.1/terms/Build/Build> a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Class that describes a build instance of software/artifacts."@en ;
-    rdfs:subClassOf ns1:Element ;
+    rdfs:subClassOf ns2:Element ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:DictionaryEntry ;
+    sh:property [ sh:class ns2:Hash ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path <https://spdx.org/rdf/3.0.1/terms/Build/parameter> ],
+            sh:path <https://spdx.org/rdf/3.0.1/terms/Build/configSourceDigest> ],
         [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path <https://spdx.org/rdf/3.0.1/terms/Build/buildEndTime> ;
             sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:class ns1:DictionaryEntry ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path <https://spdx.org/rdf/3.0.1/terms/Build/environment> ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path <https://spdx.org/rdf/3.0.1/terms/Build/buildId> ],
         [ sh:datatype xsd:anyURI ;
-            sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.0.1/terms/Build/configSourceUri> ],
-        [ sh:class ns1:Hash ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path <https://spdx.org/rdf/3.0.1/terms/Build/configSourceDigest> ],
-        [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path <https://spdx.org/rdf/3.0.1/terms/Build/buildType> ],
+        [ sh:class ns2:DictionaryEntry ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <https://spdx.org/rdf/3.0.1/terms/Build/parameter> ],
         [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path <https://spdx.org/rdf/3.0.1/terms/Build/buildStartTime> ;
             sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+        [ sh:datatype xsd:anyURI ;
+            sh:nodeKind sh:Literal ;
+            sh:path <https://spdx.org/rdf/3.0.1/terms/Build/configSourceUri> ],
+        [ sh:class ns2:DictionaryEntry ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <https://spdx.org/rdf/3.0.1/terms/Build/environment> ],
         [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:path <https://spdx.org/rdf/3.0.1/terms/Build/configSourceEntrypoint> ] .
 
-ns1:Annotation a owl:Class,
+ns2:Annotation a owl:Class,
         sh:NodeShape ;
     rdfs:comment "An assertion made in relation to one or more elements."@en ;
-    rdfs:subClassOf ns1:Element ;
+    rdfs:subClassOf ns2:Element ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:AnnotationType ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:contentType ;
+            sh:pattern "^[^\\/]+\\/[^\\/]+$" ],
+        [ sh:class ns2:Element ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns2:subject ],
+        [ sh:class ns2:AnnotationType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/AnnotationType/other> <https://spdx.org/rdf/3.0.1/terms/Core/AnnotationType/review> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:annotationType ],
+            sh:path ns2:annotationType ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:contentType ;
-            sh:pattern "^[^\\/]+\\/[^\\/]+$" ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:statement ],
-        [ sh:class ns1:Element ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:subject ] .
+            sh:path ns2:statement ] .
 
-ns1:LifecycleScopedRelationship a owl:Class,
+ns2:LifecycleScopedRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Provide context for a relationship that occurs in the lifecycle."@en ;
-    rdfs:subClassOf ns1:Relationship ;
+    rdfs:subClassOf ns2:Relationship ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:LifecycleScopeType ;
+    sh:property [ sh:class ns2:LifecycleScopeType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType/design> <https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType/development> <https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType/build> <https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType/test> <https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType/runtime> <https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType/other> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:scope ] .
+            sh:path ns2:scope ] .
 
-ns1:Organization a owl:Class ;
-    rdfs:comment "A group of people who work together in an organized way for a shared purpose."@en ;
-    rdfs:subClassOf ns1:Agent ;
-    sh:nodeKind sh:IRI .
+ns2:NoAssertionElement a owl:NamedIndividual,
+        ns2:Element ;
+    rdfs:comment """An Individual Value for Element representing a set of Elements of unknown
+identify or cardinality (number)."""@en .
 
-ns1:PackageVerificationCode a owl:Class,
+ns2:NoneElement a owl:NamedIndividual,
+        ns2:Element ;
+    rdfs:comment """An Individual Value for Element representing a set of Elements with
+cardinality (number/count) of zero."""@en .
+
+ns2:PackageVerificationCode a owl:Class,
         sh:NodeShape ;
     rdfs:comment "An SPDX version 2.X compatible verification method for software packages."@en ;
-    rdfs:subClassOf ns1:IntegrityMethod ;
+    rdfs:subClassOf ns2:IntegrityMethod ;
     sh:nodeKind sh:BlankNode ;
     sh:property [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:packageVerificationCodeExcludedFile ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:hashValue ],
-        [ sh:class ns1:HashAlgorithm ;
+            sh:path ns2:packageVerificationCodeExcludedFile ],
+        [ sh:class ns2:HashAlgorithm ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/adler32> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/blake2b256> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/blake2b384> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/blake2b512> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/blake3> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/crystalsDilithium> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/crystalsKyber> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/falcon> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/md2> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/md4> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/md5> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/md6> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/other> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha1> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha224> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha256> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha384> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha512> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha3_224> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha3_256> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha3_384> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha3_512> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:algorithm ] .
+            sh:path ns2:algorithm ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:hashValue ] .
 
-ns1:Person a owl:Class ;
+ns2:Person a owl:Class ;
     rdfs:comment "An individual human being."@en ;
-    rdfs:subClassOf ns1:Agent ;
+    rdfs:subClassOf ns2:Agent ;
     sh:nodeKind sh:IRI .
 
-ns1:SoftwareAgent a owl:Class ;
+ns2:SoftwareAgent a owl:Class ;
     rdfs:comment "A software agent."@en ;
-    rdfs:subClassOf ns1:Agent ;
+    rdfs:subClassOf ns2:Agent ;
     sh:nodeKind sh:IRI .
 
-ns1:SpdxDocument a owl:Class,
+ns2:SpdxDocument a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A collection of SPDX Elements that could potentially be serialized."@en ;
-    rdfs:subClassOf ns1:ElementCollection ;
+    rdfs:subClassOf ns2:ElementCollection ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> ;
+    sh:property [ sh:class ns2:NamespaceMap ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns2:namespaceMap ],
+        [ sh:class <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:dataLicense ],
-        [ sh:class ns1:NamespaceMap ;
+            sh:path ns2:dataLicense ],
+        [ sh:class ns2:ExternalMap ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:namespaceMap ],
-        [ sh:class ns1:ExternalMap ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:import ] .
+            sh:path ns2:import ] .
+
+ns2:SpdxOrganization a owl:NamedIndividual,
+        ns2:Organization ;
+    rdfs:comment "An Organization representing the SPDX Project."@en ;
+    owl:sameAs <https://spdx.org/> .
 
 ns4:DatasetPackage a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Specifies a data package and its associated information."@en ;
-    rdfs:subClassOf ns5:Package ;
+    rdfs:subClassOf ns1:Package ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns4:anonymizationMethodUsed ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns4:intendedUse ],
-        [ sh:class ns1:PresenceType ;
-            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/yes> <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/no> <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/noAssertion> ) ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns4:hasSensitivePersonalInformation ],
-        [ sh:class ns4:DatasetType ;
+    sh:property [ sh:class ns4:DatasetType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/audio> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/categorical> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/graph> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/image> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/noAssertion> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/numeric> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/other> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/sensor> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/structured> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/syntactic> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/text> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/timeseries> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/timestamp> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/video> ) ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:path ns4:datasetType ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns4:datasetUpdateMechanism ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns4:dataPreprocessing ],
-        [ sh:class ns4:ConfidentialityLevelType ;
-            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Dataset/ConfidentialityLevelType/red> <https://spdx.org/rdf/3.0.1/terms/Dataset/ConfidentialityLevelType/amber> <https://spdx.org/rdf/3.0.1/terms/Dataset/ConfidentialityLevelType/green> <https://spdx.org/rdf/3.0.1/terms/Dataset/ConfidentialityLevelType/clear> ) ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns4:confidentialityLevel ],
         [ sh:class ns4:DatasetAvailabilityType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetAvailabilityType/clickthrough> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetAvailabilityType/directDownload> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetAvailabilityType/query> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetAvailabilityType/registration> <https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetAvailabilityType/scrapingScript> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:path ns4:datasetAvailability ],
-        [ sh:class ns1:DictionaryEntry ;
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns4:anonymizationMethodUsed ],
+        [ sh:class ns2:DictionaryEntry ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:path ns4:sensor ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:datasetNoise ],
+            sh:path ns4:dataCollectionProcess ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:dataCollectionProcess ],
+            sh:path ns4:intendedUse ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns4:datasetNoise ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns4:dataPreprocessing ],
         [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:path ns4:knownBias ],
+        [ sh:class ns2:PresenceType ;
+            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/yes> <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/no> <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/noAssertion> ) ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns4:hasSensitivePersonalInformation ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns4:datasetUpdateMechanism ],
         [ sh:datatype xsd:nonNegativeInteger ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:datasetSize ] .
+            sh:path ns4:datasetSize ],
+        [ sh:class ns4:ConfidentialityLevelType ;
+            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Dataset/ConfidentialityLevelType/red> <https://spdx.org/rdf/3.0.1/terms/Dataset/ConfidentialityLevelType/amber> <https://spdx.org/rdf/3.0.1/terms/Dataset/ConfidentialityLevelType/green> <https://spdx.org/rdf/3.0.1/terms/Dataset/ConfidentialityLevelType/clear> ) ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns4:confidentialityLevel ] .
 
-ns3:ConjunctiveLicenseSet a owl:Class,
+ns6:ConjunctiveLicenseSet a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Portion of an AnyLicenseInfo representing a set of licensing information
 where all elements apply."""@en ;
@@ -270,19 +279,19 @@ where all elements apply."""@en ;
     sh:property [ sh:class <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> ;
             sh:minCount 2 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns3:member ] .
+            sh:path ns6:member ] .
 
-ns3:CustomLicense a owl:Class ;
+ns6:CustomLicense a owl:Class ;
     rdfs:comment "A license that is not listed on the SPDX License List."@en ;
-    rdfs:subClassOf ns3:License ;
+    rdfs:subClassOf ns6:License ;
     sh:nodeKind sh:IRI .
 
-ns3:CustomLicenseAddition a owl:Class ;
+ns6:CustomLicenseAddition a owl:Class ;
     rdfs:comment "A license addition that is not listed on the SPDX Exceptions List."@en ;
-    rdfs:subClassOf ns3:LicenseAddition ;
+    rdfs:subClassOf ns6:LicenseAddition ;
     sh:nodeKind sh:IRI .
 
-ns3:DisjunctiveLicenseSet a owl:Class,
+ns6:DisjunctiveLicenseSet a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Portion of an AnyLicenseInfo representing a set of licensing information where
 only one of the elements applies."""@en ;
@@ -291,78 +300,76 @@ only one of the elements applies."""@en ;
     sh:property [ sh:class <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> ;
             sh:minCount 2 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns3:member ] .
+            sh:path ns6:member ] .
 
-ns3:ListedLicense a owl:Class,
+ns6:ListedLicense a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A license that is listed on the SPDX License List."@en ;
-    rdfs:subClassOf ns3:License ;
+    rdfs:subClassOf ns6:License ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:deprecatedVersion ],
+            sh:path ns6:listVersionAdded ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:listVersionAdded ] .
+            sh:path ns6:deprecatedVersion ] .
 
-ns3:ListedLicenseException a owl:Class,
+ns6:ListedLicenseException a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A license exception that is listed on the SPDX Exceptions list."@en ;
-    rdfs:subClassOf ns3:LicenseAddition ;
+    rdfs:subClassOf ns6:LicenseAddition ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:deprecatedVersion ],
+            sh:path ns6:deprecatedVersion ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:listVersionAdded ] .
+            sh:path ns6:listVersionAdded ] .
 
-ns3:NoAssertionLicense a owl:NamedIndividual,
-        ns3:IndividualLicensingInfo ;
+ns6:NoAssertionLicense a owl:NamedIndividual,
+        ns6:IndividualLicensingInfo ;
     rdfs:comment """An Individual Value for License when no assertion can be made about its actual
 value."""@en ;
-    rdfs:range ns3:IndividualLicensingInfo ;
     owl:sameAs <https://spdx.org/rdf/3.0.1/terms/Licensing/NoAssertion> .
 
-ns3:NoneLicense a owl:NamedIndividual,
-        ns3:IndividualLicensingInfo ;
+ns6:NoneLicense a owl:NamedIndividual,
+        ns6:IndividualLicensingInfo ;
     rdfs:comment """An Individual Value for License where the SPDX data creator determines that no
 license is present."""@en ;
-    rdfs:range ns3:IndividualLicensingInfo ;
     owl:sameAs <https://spdx.org/rdf/3.0.1/terms/Licensing/None> .
 
-ns3:OrLaterOperator a owl:Class,
+ns6:OrLaterOperator a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Portion of an AnyLicenseInfo representing this version, or any later version,
 of the indicated License."""@en ;
-    rdfs:subClassOf ns3:ExtendableLicense ;
+    rdfs:subClassOf ns6:ExtendableLicense ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns3:License ;
+    sh:property [ sh:class ns6:License ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns3:subjectLicense ] .
+            sh:path ns6:subjectLicense ] .
 
-ns3:WithAdditionOperator a owl:Class,
+ns6:WithAdditionOperator a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Portion of an AnyLicenseInfo representing a License which has additional
 text applied to it."""@en ;
     rdfs:subClassOf <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns3:LicenseAddition ;
+    sh:property [ sh:class ns6:ExtendableLicense ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns3:subjectAddition ],
-        [ sh:class ns3:ExtendableLicense ;
+            sh:path ns6:subjectExtendableLicense ],
+        [ sh:class ns6:LicenseAddition ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns3:subjectExtendableLicense ] .
+            sh:path ns6:subjectAddition ] .
 
 <https://spdx.org/rdf/3.0.1/terms/Extension/CdxPropertiesExtension> a owl:Class,
         sh:NodeShape ;
@@ -374,183 +381,185 @@ text applied to it."""@en ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:path <https://spdx.org/rdf/3.0.1/terms/Extension/cdxProperty> ] .
 
-ns2:CvssV2VulnAssessmentRelationship a owl:Class,
+ns3:CvssV2VulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Provides a CVSS version 2.0 assessment for a vulnerability."@en ;
-    rdfs:subClassOf ns2:VulnAssessmentRelationship ;
+    rdfs:subClassOf ns3:VulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:decimal ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:score ],
+            sh:path ns3:score ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:vectorString ] .
+            sh:path ns3:vectorString ] .
 
-ns2:CvssV3VulnAssessmentRelationship a owl:Class,
+ns3:CvssV3VulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Provides a CVSS version 3 assessment for a vulnerability."@en ;
-    rdfs:subClassOf ns2:VulnAssessmentRelationship ;
+    rdfs:subClassOf ns3:VulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:vectorString ],
-        [ sh:class ns2:CvssSeverityType ;
+            sh:path ns3:vectorString ],
+        [ sh:class ns3:CvssSeverityType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/critical> <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/high> <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/medium> <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/low> <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/none> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns2:severity ],
+            sh:path ns3:severity ],
         [ sh:datatype xsd:decimal ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:score ] .
+            sh:path ns3:score ] .
 
-ns2:CvssV4VulnAssessmentRelationship a owl:Class,
+ns3:CvssV4VulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Provides a CVSS version 4 assessment for a vulnerability."@en ;
-    rdfs:subClassOf ns2:VulnAssessmentRelationship ;
+    rdfs:subClassOf ns3:VulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns2:CvssSeverityType ;
+    sh:property [ sh:class ns3:CvssSeverityType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/critical> <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/high> <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/medium> <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/low> <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/none> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns2:severity ],
+            sh:path ns3:severity ],
+        [ sh:datatype xsd:decimal ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns3:score ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:vectorString ],
-        [ sh:datatype xsd:decimal ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns2:score ] .
+            sh:path ns3:vectorString ] .
 
-ns2:EpssVulnAssessmentRelationship a owl:Class,
+ns3:EpssVulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Provides an EPSS assessment for a vulnerability."@en ;
-    rdfs:subClassOf ns2:VulnAssessmentRelationship ;
+    rdfs:subClassOf ns3:VulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:decimal ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:percentile ],
+            sh:path ns3:percentile ],
         [ sh:datatype xsd:decimal ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:probability ] .
+            sh:path ns3:probability ] .
 
-ns2:ExploitCatalogVulnAssessmentRelationship a owl:Class,
+ns3:ExploitCatalogVulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Provides an exploit assessment of a vulnerability."@en ;
-    rdfs:subClassOf ns2:VulnAssessmentRelationship ;
+    rdfs:subClassOf ns3:VulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:boolean ;
+    sh:property [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:exploited ],
-        [ sh:datatype xsd:anyURI ;
+            sh:path ns3:locator ],
+        [ sh:datatype xsd:boolean ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:locator ],
-        [ sh:class ns2:ExploitCatalogType ;
+            sh:path ns3:exploited ],
+        [ sh:class ns3:ExploitCatalogType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Security/ExploitCatalogType/kev> <https://spdx.org/rdf/3.0.1/terms/Security/ExploitCatalogType/other> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns2:catalogType ] .
+            sh:path ns3:catalogType ] .
 
-ns2:SsvcVulnAssessmentRelationship a owl:Class,
+ns3:SsvcVulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Provides an SSVC assessment for a vulnerability."@en ;
-    rdfs:subClassOf ns2:VulnAssessmentRelationship ;
+    rdfs:subClassOf ns3:VulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns2:SsvcDecisionType ;
+    sh:property [ sh:class ns3:SsvcDecisionType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Security/SsvcDecisionType/act> <https://spdx.org/rdf/3.0.1/terms/Security/SsvcDecisionType/attend> <https://spdx.org/rdf/3.0.1/terms/Security/SsvcDecisionType/track> <https://spdx.org/rdf/3.0.1/terms/Security/SsvcDecisionType/trackStar> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns2:decisionType ] .
+            sh:path ns3:decisionType ] .
 
-ns2:VexAffectedVulnAssessmentRelationship a owl:Class,
+ns3:VexAffectedVulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Connects a vulnerability and an element designating the element as a product
 affected by the vulnerability."""@en ;
-    rdfs:subClassOf ns2:VexVulnAssessmentRelationship ;
+    rdfs:subClassOf ns3:VexVulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:actionStatementTime ;
+            sh:path ns3:actionStatementTime ;
             sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
+            sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:actionStatement ] .
+            sh:path ns3:actionStatement ] .
 
-ns2:VexFixedVulnAssessmentRelationship a owl:Class ;
+ns3:VexFixedVulnAssessmentRelationship a owl:Class ;
     rdfs:comment """Links a vulnerability and elements representing products (in the VEX sense) where
 a fix has been applied and are no longer affected."""@en ;
-    rdfs:subClassOf ns2:VexVulnAssessmentRelationship ;
+    rdfs:subClassOf ns3:VexVulnAssessmentRelationship ;
     sh:nodeKind sh:IRI .
 
-ns2:VexNotAffectedVulnAssessmentRelationship a owl:Class,
+ns3:VexNotAffectedVulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Links a vulnerability and one or more elements designating the latter as products
 not affected by the vulnerability."""@en ;
-    rdfs:subClassOf ns2:VexVulnAssessmentRelationship ;
+    rdfs:subClassOf ns3:VexVulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns2:VexJustificationType ;
+    sh:property [ sh:class ns3:VexJustificationType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Security/VexJustificationType/componentNotPresent> <https://spdx.org/rdf/3.0.1/terms/Security/VexJustificationType/vulnerableCodeNotPresent> <https://spdx.org/rdf/3.0.1/terms/Security/VexJustificationType/vulnerableCodeCannotBeControlledByAdversary> <https://spdx.org/rdf/3.0.1/terms/Security/VexJustificationType/vulnerableCodeNotInExecutePath> <https://spdx.org/rdf/3.0.1/terms/Security/VexJustificationType/inlineMitigationsAlreadyExist> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns2:justificationType ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns2:impactStatement ],
+            sh:path ns3:justificationType ],
         [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:impactStatementTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ] .
+            sh:path ns3:impactStatementTime ;
+            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns3:impactStatement ] .
 
-ns2:VexUnderInvestigationVulnAssessmentRelationship a owl:Class ;
+ns3:VexUnderInvestigationVulnAssessmentRelationship a owl:Class ;
     rdfs:comment """Designates elements as products where the impact of a vulnerability is being
 investigated."""@en ;
-    rdfs:subClassOf ns2:VexVulnAssessmentRelationship ;
+    rdfs:subClassOf ns3:VexVulnAssessmentRelationship ;
     sh:nodeKind sh:IRI .
 
-ns2:Vulnerability a owl:Class,
+ns3:Vulnerability a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Specifies a vulnerability and its associated information."@en ;
-    rdfs:subClassOf ns1:Artifact ;
+    rdfs:subClassOf ns2:Artifact ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:modifiedTime ;
+            sh:path ns3:modifiedTime ;
             sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
         [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:withdrawnTime ;
+            sh:path ns3:publishedTime ;
             sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
         [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:publishedTime ;
+            sh:path ns3:withdrawnTime ;
             sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ] .
 
 <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/LicenseExpression> a owl:Class,
@@ -558,14 +567,14 @@ ns2:Vulnerability a owl:Class,
     rdfs:comment "An SPDX Element containing an SPDX license expression string."@en ;
     rdfs:subClassOf <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:DictionaryEntry ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/customIdToUri> ],
-        [ sh:datatype xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/licenseExpression> ],
+        [ sh:class ns2:DictionaryEntry ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/customIdToUri> ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
@@ -575,7 +584,7 @@ ns2:Vulnerability a owl:Class,
 <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/SimpleLicensingText> a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A license or addition that is not listed on the SPDX License List."@en ;
-    rdfs:subClassOf ns1:Element ;
+    rdfs:subClassOf ns2:Element ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
@@ -583,34 +592,34 @@ ns2:Vulnerability a owl:Class,
             sh:nodeKind sh:Literal ;
             sh:path <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/licenseText> ] .
 
-ns5:Sbom a owl:Class,
+ns1:Sbom a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A collection of SPDX Elements describing a single package."@en ;
-    rdfs:subClassOf ns1:Bom ;
+    rdfs:subClassOf ns2:Bom ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns5:SbomType ;
+    sh:property [ sh:class ns1:SbomType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Software/SbomType/design> <https://spdx.org/rdf/3.0.1/terms/Software/SbomType/source> <https://spdx.org/rdf/3.0.1/terms/Software/SbomType/build> <https://spdx.org/rdf/3.0.1/terms/Software/SbomType/deployed> <https://spdx.org/rdf/3.0.1/terms/Software/SbomType/runtime> <https://spdx.org/rdf/3.0.1/terms/Software/SbomType/analyzed> ) ;
             sh:nodeKind sh:IRI ;
-            sh:path ns5:sbomType ] .
+            sh:path ns1:sbomType ] .
 
-ns5:Snippet a owl:Class,
+ns1:Snippet a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Describes a certain part of a file."@en ;
-    rdfs:subClassOf ns5:SoftwareArtifact ;
+    rdfs:subClassOf ns1:SoftwareArtifact ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns5:File ;
+    sh:property [ sh:class ns2:PositiveIntegerRange ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns1:byteRange ],
+        [ sh:class ns2:PositiveIntegerRange ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns1:lineRange ],
+        [ sh:class ns1:File ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns5:snippetFromFile ],
-        [ sh:class ns1:PositiveIntegerRange ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns5:lineRange ],
-        [ sh:class ns1:PositiveIntegerRange ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns5:byteRange ] .
+            sh:path ns1:snippetFromFile ] .
 
 spdx: a owl:Ontology ;
     rdfs:label "System Package Data Exchange (SPDX) Ontology"@en ;
@@ -624,128 +633,128 @@ spdx: a owl:Ontology ;
     omg-ann:copyright "Copyright (C) 2024 SPDX Project"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/AI/EnergyUnitType/kilowattHour> a owl:NamedIndividual,
-        ns6:EnergyUnitType ;
+        ns5:EnergyUnitType ;
     rdfs:label "kilowattHour" ;
     rdfs:comment "Kilowatt-hour."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/AI/EnergyUnitType/megajoule> a owl:NamedIndividual,
-        ns6:EnergyUnitType ;
+        ns5:EnergyUnitType ;
     rdfs:label "megajoule" ;
     rdfs:comment "Megajoule."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/AI/EnergyUnitType/other> a owl:NamedIndividual,
-        ns6:EnergyUnitType ;
+        ns5:EnergyUnitType ;
     rdfs:label "other" ;
     rdfs:comment "Any other units of energy measurement."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/AI/SafetyRiskAssessmentType/high> a owl:NamedIndividual,
-        ns6:SafetyRiskAssessmentType ;
+        ns5:SafetyRiskAssessmentType ;
     rdfs:label "high" ;
     rdfs:comment "The second-highest level of risk posed by an AI system."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/AI/SafetyRiskAssessmentType/low> a owl:NamedIndividual,
-        ns6:SafetyRiskAssessmentType ;
+        ns5:SafetyRiskAssessmentType ;
     rdfs:label "low" ;
     rdfs:comment "Low/no risk is posed by an AI system."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/AI/SafetyRiskAssessmentType/medium> a owl:NamedIndividual,
-        ns6:SafetyRiskAssessmentType ;
+        ns5:SafetyRiskAssessmentType ;
     rdfs:label "medium" ;
     rdfs:comment "The third-highest level of risk posed by an AI system."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/AI/SafetyRiskAssessmentType/serious> a owl:NamedIndividual,
-        ns6:SafetyRiskAssessmentType ;
+        ns5:SafetyRiskAssessmentType ;
     rdfs:label "serious" ;
     rdfs:comment "The highest level of risk posed by an AI system."@en .
 
-ns6:autonomyType a owl:ObjectProperty ;
+ns5:autonomyType a owl:ObjectProperty ;
     rdfs:comment """Indicates whether the system can perform a decision or action without human
 involvement or guidance."""@en ;
-    rdfs:range ns1:PresenceType .
+    rdfs:range ns2:PresenceType .
 
-ns6:domain a owl:DatatypeProperty ;
+ns5:domain a owl:DatatypeProperty ;
     rdfs:comment "Captures the domain in which the AI package can be used."@en ;
     rdfs:range xsd:string .
 
-ns6:energyConsumption a owl:ObjectProperty ;
+ns5:energyConsumption a owl:ObjectProperty ;
     rdfs:comment "Indicates the amount of energy consumption incurred by an AI model."@en ;
-    rdfs:range ns6:EnergyConsumption .
+    rdfs:range ns5:EnergyConsumption .
 
-ns6:energyQuantity a owl:DatatypeProperty ;
+ns5:energyQuantity a owl:DatatypeProperty ;
     rdfs:comment "Represents the energy quantity."@en ;
     rdfs:range xsd:decimal .
 
-ns6:energyUnit a owl:ObjectProperty ;
+ns5:energyUnit a owl:ObjectProperty ;
     rdfs:comment "Specifies the unit in which energy is measured."@en ;
-    rdfs:range ns6:EnergyUnitType .
+    rdfs:range ns5:EnergyUnitType .
 
-ns6:finetuningEnergyConsumption a owl:ObjectProperty ;
+ns5:finetuningEnergyConsumption a owl:ObjectProperty ;
     rdfs:comment """Specifies the amount of energy consumed when finetuning the AI model that is
 being used in the AI system."""@en ;
-    rdfs:range ns6:EnergyConsumptionDescription .
+    rdfs:range ns5:EnergyConsumptionDescription .
 
-ns6:hyperparameter a owl:ObjectProperty ;
+ns5:hyperparameter a owl:ObjectProperty ;
     rdfs:comment """Records a hyperparameter used to build the AI model contained in the AI
 package."""@en ;
-    rdfs:range ns1:DictionaryEntry .
+    rdfs:range ns2:DictionaryEntry .
 
-ns6:inferenceEnergyConsumption a owl:ObjectProperty ;
+ns5:inferenceEnergyConsumption a owl:ObjectProperty ;
     rdfs:comment """Specifies the amount of energy consumed during inference time by an AI model
 that is being used in the AI system."""@en ;
-    rdfs:range ns6:EnergyConsumptionDescription .
+    rdfs:range ns5:EnergyConsumptionDescription .
 
-ns6:informationAboutApplication a owl:DatatypeProperty ;
+ns5:informationAboutApplication a owl:DatatypeProperty ;
     rdfs:comment """Provides relevant information about the AI software, not including the model
 description."""@en ;
     rdfs:range xsd:string .
 
-ns6:informationAboutTraining a owl:DatatypeProperty ;
+ns5:informationAboutTraining a owl:DatatypeProperty ;
     rdfs:comment "Describes relevant information about different steps of the training process."@en ;
     rdfs:range xsd:string .
 
-ns6:limitation a owl:DatatypeProperty ;
+ns5:limitation a owl:DatatypeProperty ;
     rdfs:comment "Captures a limitation of the AI software."@en ;
     rdfs:range xsd:string .
 
-ns6:metric a owl:ObjectProperty ;
+ns5:metric a owl:ObjectProperty ;
     rdfs:comment "Records the measurement of prediction quality of the AI model."@en ;
-    rdfs:range ns1:DictionaryEntry .
+    rdfs:range ns2:DictionaryEntry .
 
-ns6:metricDecisionThreshold a owl:ObjectProperty ;
+ns5:metricDecisionThreshold a owl:ObjectProperty ;
     rdfs:comment """Captures the threshold that was used for computation of a metric described in
 the metric field."""@en ;
-    rdfs:range ns1:DictionaryEntry .
+    rdfs:range ns2:DictionaryEntry .
 
-ns6:modelDataPreprocessing a owl:DatatypeProperty ;
+ns5:modelDataPreprocessing a owl:DatatypeProperty ;
     rdfs:comment """Describes all the preprocessing steps applied to the training data before the
 model training."""@en ;
     rdfs:range xsd:string .
 
-ns6:modelExplainability a owl:DatatypeProperty ;
+ns5:modelExplainability a owl:DatatypeProperty ;
     rdfs:comment "Describes methods that can be used to explain the results from the AI model."@en ;
     rdfs:range xsd:string .
 
-ns6:safetyRiskAssessment a owl:ObjectProperty ;
+ns5:safetyRiskAssessment a owl:ObjectProperty ;
     rdfs:comment "Records the results of general safety risk assessment of the AI system."@en ;
-    rdfs:range ns6:SafetyRiskAssessmentType .
+    rdfs:range ns5:SafetyRiskAssessmentType .
 
-ns6:standardCompliance a owl:DatatypeProperty ;
+ns5:standardCompliance a owl:DatatypeProperty ;
     rdfs:comment "Captures a standard that is being complied with."@en ;
     rdfs:range xsd:string .
 
-ns6:trainingEnergyConsumption a owl:ObjectProperty ;
+ns5:trainingEnergyConsumption a owl:ObjectProperty ;
     rdfs:comment """Specifies the amount of energy consumed when training the AI model that is
 being used in the AI system."""@en ;
-    rdfs:range ns6:EnergyConsumptionDescription .
+    rdfs:range ns5:EnergyConsumptionDescription .
 
-ns6:typeOfModel a owl:DatatypeProperty ;
+ns5:typeOfModel a owl:DatatypeProperty ;
     rdfs:comment "Records the type of the model used in the AI software."@en ;
     rdfs:range xsd:string .
 
-ns6:useSensitivePersonalInformation a owl:ObjectProperty ;
+ns5:useSensitivePersonalInformation a owl:ObjectProperty ;
     rdfs:comment """Records if sensitive personal information is used during model training or
 could be used during the inference."""@en ;
-    rdfs:range ns1:PresenceType .
+    rdfs:range ns2:PresenceType .
 
 <https://spdx.org/rdf/3.0.1/terms/Build/buildEndTime> a owl:DatatypeProperty ;
     rdfs:comment "Property that describes the time at which a build stops."@en ;
@@ -768,7 +777,7 @@ infrastructure that the build was invoked on."""@en ;
 <https://spdx.org/rdf/3.0.1/terms/Build/configSourceDigest> a owl:ObjectProperty ;
     rdfs:comment """Property that describes the digest of the build configuration file used to
 invoke a build."""@en ;
-    rdfs:range ns1:Hash .
+    rdfs:range ns2:Hash .
 
 <https://spdx.org/rdf/3.0.1/terms/Build/configSourceEntrypoint> a owl:DatatypeProperty ;
     rdfs:comment "Property describes the invocation entrypoint of a build."@en ;
@@ -780,970 +789,961 @@ invoke a build."""@en ;
 
 <https://spdx.org/rdf/3.0.1/terms/Build/environment> a owl:ObjectProperty ;
     rdfs:comment "Property describing the session in which a build is invoked."@en ;
-    rdfs:range ns1:DictionaryEntry .
+    rdfs:range ns2:DictionaryEntry .
 
 <https://spdx.org/rdf/3.0.1/terms/Build/parameter> a owl:ObjectProperty ;
     rdfs:comment "Property describing a parameter used in an instance of a build."@en ;
-    rdfs:range ns1:DictionaryEntry .
+    rdfs:range ns2:DictionaryEntry .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/AnnotationType/other> a owl:NamedIndividual,
-        ns1:AnnotationType ;
+        ns2:AnnotationType ;
     rdfs:label "other" ;
-    rdfs:comment "Used to store extra information about an Element which is not part of a Review (e.g. extra information provided during the creation of the Element)."@en .
+    rdfs:comment "Used to store extra information about an Element which is not part of a review (e.g. extra information provided during the creation of the Element)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/AnnotationType/review> a owl:NamedIndividual,
-        ns1:AnnotationType ;
+        ns2:AnnotationType ;
     rdfs:label "review" ;
     rdfs:comment "Used when someone reviews the Element."@en .
 
-ns1:Bom a owl:Class ;
+ns2:Bom a owl:Class ;
     rdfs:comment """A container for a grouping of SPDX-3.0 content characterizing details
 (provenence, composition, licensing, etc.) about a product."""@en ;
-    rdfs:subClassOf ns1:Bundle ;
+    rdfs:subClassOf ns2:Bundle ;
     sh:nodeKind sh:IRI .
 
-ns1:Bundle a owl:Class,
+ns2:Bundle a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A collection of Elements that have a shared context."@en ;
-    rdfs:subClassOf ns1:ElementCollection ;
+    rdfs:subClassOf ns2:ElementCollection ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:context ] .
+            sh:path ns2:context ] .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/cpe22> a owl:NamedIndividual,
-        ns1:ExternalIdentifierType ;
+        ns2:ExternalIdentifierType ;
     rdfs:label "cpe22" ;
     rdfs:comment "[Common Platform Enumeration Specification 2.2](https://cpe.mitre.org/files/cpe-specification_2.2.pdf)"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/cpe23> a owl:NamedIndividual,
-        ns1:ExternalIdentifierType ;
+        ns2:ExternalIdentifierType ;
     rdfs:label "cpe23" ;
     rdfs:comment "[Common Platform Enumeration: Naming Specification Version 2.3](https://csrc.nist.gov/publications/detail/nistir/7695/final)"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/cve> a owl:NamedIndividual,
-        ns1:ExternalIdentifierType ;
+        ns2:ExternalIdentifierType ;
     rdfs:label "cve" ;
     rdfs:comment "Common Vulnerabilities and Exposures identifiers, an identifier for a specific software flaw defined within the official CVE Dictionary and that conforms to the [CVE specification](https://csrc.nist.gov/glossary/term/cve_id)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/email> a owl:NamedIndividual,
-        ns1:ExternalIdentifierType ;
+        ns2:ExternalIdentifierType ;
     rdfs:label "email" ;
-    rdfs:comment "Email address, as defined in [RFC 3696](https://www.rfc-editor.org/info/rfc3986) Section 3."@en .
+    rdfs:comment "Email address, as defined in [RFC 3696](https://datatracker.ietf.org/doc/rfc3986/) Section 3."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/gitoid> a owl:NamedIndividual,
-        ns1:ExternalIdentifierType ;
+        ns2:ExternalIdentifierType ;
     rdfs:label "gitoid" ;
     rdfs:comment "[Gitoid](https://www.iana.org/assignments/uri-schemes/prov/gitoid), stands for [Git Object ID](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects). A gitoid of type blob is a unique hash of a binary artifact. A gitoid may represent either an [Artifact Identifier](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#artifact-identifier-types) for the software artifact or an [Input Manifest Identifier](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#input-manifest-identifier) for the software artifact's associated [Artifact Input Manifest](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#artifact-input-manifest); this ambiguity exists because the Artifact Input Manifest is itself an artifact, and the gitoid of that artifact is its valid identifier. Gitoids calculated on software artifacts (Snippet, File, or Package Elements) should be recorded in the SPDX 3.0 SoftwareArtifact's contentIdentifier property. Gitoids calculated on the Artifact Input Manifest (Input Manifest Identifier) should be recorded in the SPDX 3.0 Element's externalIdentifier property. See [OmniBOR Specification](https://github.com/omnibor/spec/), a minimalistic specification for describing software [Artifact Dependency Graphs](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#artifact-dependency-graph-adg)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/other> a owl:NamedIndividual,
-        ns1:ExternalIdentifierType ;
+        ns2:ExternalIdentifierType ;
     rdfs:label "other" ;
     rdfs:comment "Used when the type does not match any of the other options."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/packageUrl> a owl:NamedIndividual,
-        ns1:ExternalIdentifierType ;
+        ns2:ExternalIdentifierType ;
     rdfs:label "packageUrl" ;
     rdfs:comment "Package URL, as defined in the corresponding [Annex](../../../annexes/pkg-url-specification.md) of this specification."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/securityOther> a owl:NamedIndividual,
-        ns1:ExternalIdentifierType ;
+        ns2:ExternalIdentifierType ;
     rdfs:label "securityOther" ;
     rdfs:comment "Used when there is a security related identifier of unspecified type."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/swhid> a owl:NamedIndividual,
-        ns1:ExternalIdentifierType ;
+        ns2:ExternalIdentifierType ;
     rdfs:label "swhid" ;
     rdfs:comment "SoftWare Hash IDentifier, a persistent intrinsic identifier for digital artifacts, such as files, trees (also known as directories or folders), commits, and other objects typically found in version control systems. The format of the identifiers is defined in the [SWHID specification](https://www.swhid.org/specification/v1.1/4.Syntax) (ISO/IEC DIS 18670). They typically look like `swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2`."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/swid> a owl:NamedIndividual,
-        ns1:ExternalIdentifierType ;
+        ns2:ExternalIdentifierType ;
     rdfs:label "swid" ;
-    rdfs:comment "Concise Software Identification (CoSWID) tag, as defined in [RFC 9393](https://www.rfc-editor.org/info/rfc9393) Section 2.3."@en .
+    rdfs:comment "Concise Software Identification (CoSWID) tag, as defined in [RFC 9393](https://datatracker.ietf.org/doc/rfc9393/) Section 2.3."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/urlScheme> a owl:NamedIndividual,
-        ns1:ExternalIdentifierType ;
+        ns2:ExternalIdentifierType ;
     rdfs:label "urlScheme" ;
     rdfs:comment "[Uniform Resource Identifier (URI) Schemes](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml). The scheme used in order to locate a resource."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/altDownloadLocation> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "altDownloadLocation" ;
     rdfs:comment "A reference to an alternative download location."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/altWebPage> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "altWebPage" ;
     rdfs:comment "A reference to an alternative web page."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/binaryArtifact> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "binaryArtifact" ;
     rdfs:comment "A reference to binary artifacts related to a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/bower> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "bower" ;
     rdfs:comment "A reference to a Bower package. The package locator format, looks like `package#version`, is defined in the \"install\" section of [Bower API documentation](https://bower.io/docs/api/#install)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/buildMeta> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "buildMeta" ;
     rdfs:comment "A reference build metadata related to a published package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/buildSystem> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "buildSystem" ;
     rdfs:comment "A reference build system used to create or publish the package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/certificationReport> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "certificationReport" ;
     rdfs:comment "A reference to a certification report for a package from an accredited/independent body."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/chat> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "chat" ;
     rdfs:comment "A reference to the instant messaging system used by the maintainer for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/componentAnalysisReport> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "componentAnalysisReport" ;
     rdfs:comment "A reference to a Software Composition Analysis (SCA) report."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/cwe> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "cwe" ;
     rdfs:comment "[Common Weakness Enumeration](https://csrc.nist.gov/glossary/term/common_weakness_enumeration). A reference to a source of software flaw defined within the official [CWE List](https://cwe.mitre.org/data/) that conforms to the [CWE specification](https://cwe.mitre.org/)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/documentation> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "documentation" ;
     rdfs:comment "A reference to the documentation for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/dynamicAnalysisReport> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "dynamicAnalysisReport" ;
     rdfs:comment "A reference to a dynamic analysis report for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/eolNotice> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "eolNotice" ;
     rdfs:comment "A reference to the End Of Sale (EOS) and/or End Of Life (EOL) information related to a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/exportControlAssessment> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "exportControlAssessment" ;
     rdfs:comment "A reference to a export control assessment for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/funding> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "funding" ;
     rdfs:comment "A reference to funding information related to a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/issueTracker> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "issueTracker" ;
     rdfs:comment "A reference to the issue tracker for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/license> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "license" ;
     rdfs:comment "A reference to additional license information related to an artifact."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/mailingList> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "mailingList" ;
     rdfs:comment "A reference to the mailing list used by the maintainer for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/mavenCentral> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "mavenCentral" ;
     rdfs:comment "A reference to a Maven repository artifact. The artifact locator format is defined in the [Maven documentation](https://maven.apache.org/guides/mini/guide-naming-conventions.html) and looks like `groupId:artifactId[:version]`."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/metrics> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "metrics" ;
     rdfs:comment "A reference to metrics related to package such as OpenSSF scorecards."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/npm> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "npm" ;
     rdfs:comment "A reference to an npm package. The package locator format is defined in the [npm documentation](https://docs.npmjs.com/cli/v10/configuring-npm/package-json) and looks like `package@version`."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/nuget> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "nuget" ;
     rdfs:comment "A reference to a NuGet package. The package locator format is defined in the [NuGet documentation](https://docs.nuget.org) and looks like `package/version`."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/other> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "other" ;
     rdfs:comment "Used when the type does not match any of the other options."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/privacyAssessment> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "privacyAssessment" ;
     rdfs:comment "A reference to a privacy assessment for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/productMetadata> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "productMetadata" ;
     rdfs:comment "A reference to additional product metadata such as reference within organization's product catalog."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/purchaseOrder> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "purchaseOrder" ;
     rdfs:comment "A reference to a purchase order for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/qualityAssessmentReport> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "qualityAssessmentReport" ;
     rdfs:comment "A reference to a quality assessment for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/releaseHistory> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "releaseHistory" ;
     rdfs:comment "A reference to a published list of releases for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/releaseNotes> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "releaseNotes" ;
     rdfs:comment "A reference to the release notes for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/riskAssessment> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "riskAssessment" ;
     rdfs:comment "A reference to a risk assessment for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/runtimeAnalysisReport> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "runtimeAnalysisReport" ;
     rdfs:comment "A reference to a runtime analysis report for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/secureSoftwareAttestation> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "secureSoftwareAttestation" ;
     rdfs:comment "A reference to information assuring that the software is developed using security practices as defined by [NIST SP 800-218 Secure Software Development Framework (SSDF) Version 1.1](https://csrc.nist.gov/pubs/sp/800/218/final) or [CISA Secure Software Development Attestation Form](https://www.cisa.gov/resources-tools/resources/secure-software-development-attestation-form)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityAdversaryModel> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "securityAdversaryModel" ;
     rdfs:comment "A reference to the security adversary model for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityAdvisory> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "securityAdvisory" ;
     rdfs:comment "A reference to a published security advisory (where advisory as defined per [ISO 29147:2018](https://www.iso.org/standard/72311.html)) that may affect one or more elements, e.g., vendor advisories or specific NVD entries."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityFix> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "securityFix" ;
     rdfs:comment "A reference to the patch or source code that fixes a vulnerability."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityOther> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "securityOther" ;
     rdfs:comment "A reference to related security information of unspecified type."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityPenTestReport> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "securityPenTestReport" ;
     rdfs:comment "A reference to a [penetration test](https://en.wikipedia.org/wiki/Penetration_test) report for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityPolicy> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "securityPolicy" ;
     rdfs:comment "A reference to instructions for reporting newly discovered security vulnerabilities for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityThreatModel> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "securityThreatModel" ;
     rdfs:comment "A reference the [security threat model](https://en.wikipedia.org/wiki/Threat_model) for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/socialMedia> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "socialMedia" ;
     rdfs:comment "A reference to a social media channel for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/sourceArtifact> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "sourceArtifact" ;
     rdfs:comment "A reference to an artifact containing the sources for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/staticAnalysisReport> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "staticAnalysisReport" ;
     rdfs:comment "A reference to a static analysis report for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/support> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "support" ;
     rdfs:comment "A reference to the software support channel or other support information for a package."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/vcs> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "vcs" ;
     rdfs:comment "A reference to a version control system related to a software artifact."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/vulnerabilityDisclosureReport> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "vulnerabilityDisclosureReport" ;
     rdfs:comment "A reference to a Vulnerability Disclosure Report (VDR) which provides the software supplier's analysis and findings describing the impact (or lack of impact) that reported vulnerabilities have on packages or products in the supplier's SBOM as defined in [NIST SP 800-161 Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations](https://csrc.nist.gov/pubs/sp/800/161/r1/final)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/vulnerabilityExploitabilityAssessment> a owl:NamedIndividual,
-        ns1:ExternalRefType ;
+        ns2:ExternalRefType ;
     rdfs:label "vulnerabilityExploitabilityAssessment" ;
     rdfs:comment "A reference to a Vulnerability Exploitability eXchange (VEX) statement which provides information on whether a product is impacted by a specific vulnerability in an included package and, if affected, whether there are actions recommended to remediate. See also [NTIA VEX one-page summary](https://ntia.gov/files/ntia/publications/vex_one-page_summary.pdf)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType/build> a owl:NamedIndividual,
-        ns1:LifecycleScopeType ;
+        ns2:LifecycleScopeType ;
     rdfs:label "build" ;
     rdfs:comment "A relationship has specific context implications during an element's build phase, during development."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType/design> a owl:NamedIndividual,
-        ns1:LifecycleScopeType ;
+        ns2:LifecycleScopeType ;
     rdfs:label "design" ;
     rdfs:comment "A relationship has specific context implications during an element's design."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType/development> a owl:NamedIndividual,
-        ns1:LifecycleScopeType ;
+        ns2:LifecycleScopeType ;
     rdfs:label "development" ;
     rdfs:comment "A relationship has specific context implications during development phase of an element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType/other> a owl:NamedIndividual,
-        ns1:LifecycleScopeType ;
+        ns2:LifecycleScopeType ;
     rdfs:label "other" ;
     rdfs:comment "A relationship has other specific context information necessary to capture that the above set of enumerations does not handle."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType/runtime> a owl:NamedIndividual,
-        ns1:LifecycleScopeType ;
+        ns2:LifecycleScopeType ;
     rdfs:label "runtime" ;
     rdfs:comment "A relationship has specific context implications during the execution phase of an element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType/test> a owl:NamedIndividual,
-        ns1:LifecycleScopeType ;
+        ns2:LifecycleScopeType ;
     rdfs:label "test" ;
     rdfs:comment "A relationship has specific context implications during an element's testing phase, during development."@en .
 
-ns1:NoAssertionElement a owl:NamedIndividual,
-        ns1:Element ;
-    rdfs:comment """An Individual Value for Element representing a set of Elements of unknown
-identify or cardinality (number)."""@en ;
-    rdfs:range ns1:Element ;
-    owl:sameAs ns1:NoAssertionElement .
-
-ns1:NoneElement a owl:NamedIndividual,
-        ns1:Element ;
-    rdfs:comment """An Individual Value for Element representing a set of Elements with
-cardinality (number/count) of zero."""@en ;
-    rdfs:range ns1:Element ;
-    owl:sameAs ns1:NoneElement .
+ns2:Organization a owl:Class ;
+    rdfs:comment "A group of people who work together in an organized way for a shared purpose."@en ;
+    rdfs:subClassOf ns2:Agent ;
+    sh:nodeKind sh:IRI .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/ai> a owl:NamedIndividual,
-        ns1:ProfileIdentifierType ;
+        ns2:ProfileIdentifierType ;
     rdfs:label "ai" ;
     rdfs:comment "the element follows the AI profile specification"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/build> a owl:NamedIndividual,
-        ns1:ProfileIdentifierType ;
+        ns2:ProfileIdentifierType ;
     rdfs:label "build" ;
     rdfs:comment "the element follows the Build profile specification"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/core> a owl:NamedIndividual,
-        ns1:ProfileIdentifierType ;
+        ns2:ProfileIdentifierType ;
     rdfs:label "core" ;
     rdfs:comment "the element follows the Core profile specification"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/dataset> a owl:NamedIndividual,
-        ns1:ProfileIdentifierType ;
+        ns2:ProfileIdentifierType ;
     rdfs:label "dataset" ;
     rdfs:comment "the element follows the Dataset profile specification"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/expandedLicensing> a owl:NamedIndividual,
-        ns1:ProfileIdentifierType ;
+        ns2:ProfileIdentifierType ;
     rdfs:label "expandedLicensing" ;
     rdfs:comment "the element follows the expanded Licensing profile specification"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/extension> a owl:NamedIndividual,
-        ns1:ProfileIdentifierType ;
+        ns2:ProfileIdentifierType ;
     rdfs:label "extension" ;
     rdfs:comment "the element follows the Extension profile specification"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/lite> a owl:NamedIndividual,
-        ns1:ProfileIdentifierType ;
+        ns2:ProfileIdentifierType ;
     rdfs:label "lite" ;
     rdfs:comment "the element follows the Lite profile specification"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/security> a owl:NamedIndividual,
-        ns1:ProfileIdentifierType ;
+        ns2:ProfileIdentifierType ;
     rdfs:label "security" ;
     rdfs:comment "the element follows the Security profile specification"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/simpleLicensing> a owl:NamedIndividual,
-        ns1:ProfileIdentifierType ;
+        ns2:ProfileIdentifierType ;
     rdfs:label "simpleLicensing" ;
     rdfs:comment "the element follows the simple Licensing profile specification"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/software> a owl:NamedIndividual,
-        ns1:ProfileIdentifierType ;
+        ns2:ProfileIdentifierType ;
     rdfs:label "software" ;
     rdfs:comment "the element follows the Software profile specification"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipCompleteness/complete> a owl:NamedIndividual,
-        ns1:RelationshipCompleteness ;
+        ns2:RelationshipCompleteness ;
     rdfs:label "complete" ;
     rdfs:comment "The relationship is known to be exhaustive."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipCompleteness/incomplete> a owl:NamedIndividual,
-        ns1:RelationshipCompleteness ;
+        ns2:RelationshipCompleteness ;
     rdfs:label "incomplete" ;
     rdfs:comment "The relationship is known not to be exhaustive."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipCompleteness/noAssertion> a owl:NamedIndividual,
-        ns1:RelationshipCompleteness ;
+        ns2:RelationshipCompleteness ;
     rdfs:label "noAssertion" ;
     rdfs:comment "No assertion can be made about the completeness of the relationship."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/affects> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "affects" ;
     rdfs:comment "The `from` Vulnerability affects each `to` Element. The use of the `affects` type is constrained to `VexAffectedVulnAssessmentRelationship` classed relationships."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/amendedBy> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "amendedBy" ;
     rdfs:comment "The `from` Element is amended by each `to` Element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/ancestorOf> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "ancestorOf" ;
     rdfs:comment "The `from` Element is an ancestor of each `to` Element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/availableFrom> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "availableFrom" ;
     rdfs:comment "The `from` Element is available from the additional supplier described by each `to` Element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/configures> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "configures" ;
     rdfs:comment "The `from` Element is a configuration applied to each `to` Element, during a LifecycleScopeType period."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/contains> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "contains" ;
     rdfs:comment "The `from` Element contains each `to` Element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/coordinatedBy> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "coordinatedBy" ;
     rdfs:comment "The `from` Vulnerability is coordinatedBy the `to` Agent(s) (vendor, researcher, or consumer agent)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/copiedTo> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "copiedTo" ;
     rdfs:comment "The `from` Element has been copied to each `to` Element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/delegatedTo> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "delegatedTo" ;
     rdfs:comment "The `from` Agent is delegating an action to the Agent of the `to` Relationship (which must be of type invokedBy), during a LifecycleScopeType (e.g. the `to` invokedBy Relationship is being done on behalf of `from`)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/dependsOn> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "dependsOn" ;
     rdfs:comment "The `from` Element depends on each `to` Element, during a LifecycleScopeType period."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/descendantOf> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "descendantOf" ;
     rdfs:comment "The `from` Element is a descendant of each `to` Element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/describes> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "describes" ;
     rdfs:comment "The `from` Element describes each `to` Element. To denote the root(s) of a tree of elements in a collection, the rootElement property should be used."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/doesNotAffect> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "doesNotAffect" ;
     rdfs:comment "The `from` Vulnerability has no impact on each `to` Element. The use of the `doesNotAffect` is constrained to `VexNotAffectedVulnAssessmentRelationship` classed relationships."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/expandsTo> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "expandsTo" ;
     rdfs:comment "The `from` archive expands out as an artifact described by each `to` Element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/exploitCreatedBy> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "exploitCreatedBy" ;
     rdfs:comment "The `from` Vulnerability has had an exploit created against it by each `to` Agent."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/fixedBy> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "fixedBy" ;
     rdfs:comment "Designates a `from` Vulnerability has been fixed by the `to` Agent(s)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/fixedIn> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "fixedIn" ;
     rdfs:comment "A `from` Vulnerability has been fixed in each `to` Element. The use of the `fixedIn` type is constrained to `VexFixedVulnAssessmentRelationship` classed relationships."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/foundBy> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "foundBy" ;
     rdfs:comment "Designates a `from` Vulnerability was originally discovered by the `to` Agent(s)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/generates> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "generates" ;
     rdfs:comment "The `from` Element generates each `to` Element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasAddedFile> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasAddedFile" ;
     rdfs:comment "Every `to` Element is a file added to the `from` Element (`from` hasAddedFile `to`)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasAssessmentFor> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasAssessmentFor" ;
     rdfs:comment "Relates a `from` Vulnerability and each `to` Element with a security assessment. To be used with `VulnAssessmentRelationship` types."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasAssociatedVulnerability> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasAssociatedVulnerability" ;
     rdfs:comment "Used to associate a `from` Artifact with each `to` Vulnerability."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasConcludedLicense> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasConcludedLicense" ;
     rdfs:comment "The `from` SoftwareArtifact is concluded by the SPDX data creator to be governed by each `to` license."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDataFile> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasDataFile" ;
     rdfs:comment "The `from` Element treats each `to` Element as a data file. A data file is an artifact that stores data required or optional for the `from` Element's functionality. A data file can be a database file, an index file, a log file, an AI model file, a calibration data file, a temporary file, a backup file, and more. For AI training dataset, test dataset, test artifact, configuration data, build input data, and build output data, please consider using the more specific relationship types: `trainedOn`, `testedOn`, `hasTest`, `configures`, `hasInput`, and `hasOutput`, respectively. This relationship does not imply dependency."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDeclaredLicense> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasDeclaredLicense" ;
     rdfs:comment "The `from` SoftwareArtifact was discovered to actually contain each `to` license, for example as detected by use of automated tooling."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDeletedFile> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasDeletedFile" ;
     rdfs:comment "Every `to` Element is a file deleted from the `from` Element (`from` hasDeletedFile `to`)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDependencyManifest> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasDependencyManifest" ;
     rdfs:comment "The `from` Element has manifest files that contain dependency information in each `to` Element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDistributionArtifact> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasDistributionArtifact" ;
     rdfs:comment "The `from` Element is distributed as an artifact in each `to` Element (e.g. an RPM or archive file)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDocumentation> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasDocumentation" ;
     rdfs:comment "The `from` Element is documented by each `to` Element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDynamicLink> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasDynamicLink" ;
     rdfs:comment "The `from` Element dynamically links in each `to` Element, during a LifecycleScopeType period."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasEvidence> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasEvidence" ;
     rdfs:comment "Every `to` Element is considered as evidence for the `from` Element (`from` hasEvidence `to`)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasExample> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasExample" ;
     rdfs:comment "Every `to` Element is an example for the `from` Element (`from` hasExample `to`)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasHost> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasHost" ;
     rdfs:comment "The `from` Build was run on the `to` Element during a LifecycleScopeType period (e.g. the host that the build runs on)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasInput> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasInput" ;
     rdfs:comment "The `from` Build has each `to` Element as an input, during a LifecycleScopeType period."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasMetadata> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasMetadata" ;
     rdfs:comment "Every `to` Element is metadata about the `from` Element (`from` hasMetadata `to`)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasOptionalComponent> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasOptionalComponent" ;
     rdfs:comment "Every `to` Element is an optional component of the `from` Element (`from` hasOptionalComponent `to`)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasOptionalDependency> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasOptionalDependency" ;
     rdfs:comment "The `from` Element optionally depends on each `to` Element, during a LifecycleScopeType period."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasOutput> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasOutput" ;
     rdfs:comment "The `from` Build element generates each `to` Element as an output, during a LifecycleScopeType period."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasPrerequisite> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasPrerequisite" ;
     rdfs:comment "The `from` Element has a prerequisite on each `to` Element, during a LifecycleScopeType period."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasProvidedDependency> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasProvidedDependency" ;
     rdfs:comment "The `from` Element has a dependency on each `to` Element, dependency is not in the distributed artifact, but assumed to be provided, during a LifecycleScopeType period."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasRequirement> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasRequirement" ;
     rdfs:comment "The `from` Element has a requirement on each `to` Element, during a LifecycleScopeType period."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasSpecification> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasSpecification" ;
     rdfs:comment "Every `to` Element is a specification for the `from` Element (`from` hasSpecification `to`), during a LifecycleScopeType period."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasStaticLink> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasStaticLink" ;
     rdfs:comment "The `from` Element statically links in each `to` Element, during a LifecycleScopeType period."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasTest> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasTest" ;
     rdfs:comment "Every `to` Element is a test artifact for the `from` Element (`from` hasTest `to`), during a LifecycleScopeType period."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasTestCase> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasTestCase" ;
     rdfs:comment "Every `to` Element is a test case for the `from` Element (`from` hasTestCase `to`)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasVariant> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "hasVariant" ;
     rdfs:comment "Every `to` Element is a variant the `from` Element (`from` hasVariant `to`)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/invokedBy> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "invokedBy" ;
     rdfs:comment "The `from` Element was invoked by the `to` Agent, during a LifecycleScopeType period (for example, a Build element that describes a build step)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/modifiedBy> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "modifiedBy" ;
     rdfs:comment "The `from` Element is modified by each `to` Element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/other> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "other" ;
-    rdfs:comment "Every `to` Element is related to the `from` Element where the relationship type is not described by any of the SPDX relationhip types (this relationship is directionless)."@en .
+    rdfs:comment "Every `to` Element is related to the `from` Element where the relationship type is not described by any of the SPDX relationship types (this relationship is directionless)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/packagedBy> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "packagedBy" ;
     rdfs:comment "Every `to` Element is a packaged instance of the `from` Element (`from` packagedBy `to`)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/patchedBy> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "patchedBy" ;
     rdfs:comment "Every `to` Element is a patch for the `from` Element (`from` patchedBy `to`)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/publishedBy> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "publishedBy" ;
     rdfs:comment "Designates a `from` Vulnerability was made available for public use or reference by each `to` Agent."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/reportedBy> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "reportedBy" ;
     rdfs:comment "Designates a `from` Vulnerability was first reported to a project, vendor, or tracking database for formal identification by each `to` Agent."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/republishedBy> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "republishedBy" ;
     rdfs:comment "Designates a `from` Vulnerability's details were tracked, aggregated, and/or enriched to improve context (i.e. NVD) by each `to` Agent."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/serializedInArtifact> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "serializedInArtifact" ;
     rdfs:comment "The `from` SpdxDocument can be found in a serialized form in each `to` Artifact."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/testedOn> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "testedOn" ;
     rdfs:comment "The `from` Element has been tested on the `to` Element(s)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/trainedOn> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "trainedOn" ;
     rdfs:comment "The `from` Element has been trained on the `to` Element(s)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/underInvestigationFor> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "underInvestigationFor" ;
     rdfs:comment "The `from` Vulnerability impact is being investigated for each `to` Element. The use of the `underInvestigationFor` type is constrained to `VexUnderInvestigationVulnAssessmentRelationship` classed relationships."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/usesTool> a owl:NamedIndividual,
-        ns1:RelationshipType ;
+        ns2:RelationshipType ;
     rdfs:label "usesTool" ;
     rdfs:comment "The `from` Element uses each `to` Element as a tool, during a LifecycleScopeType period."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/deployed> a owl:NamedIndividual,
-        ns1:SupportType ;
+        ns2:SupportType ;
     rdfs:label "deployed" ;
     rdfs:comment "in addition to being supported by the supplier, the software is known to have been deployed and is in use.  For a software as a service provider, this implies the software is now available as a service."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/development> a owl:NamedIndividual,
-        ns1:SupportType ;
+        ns2:SupportType ;
     rdfs:label "development" ;
     rdfs:comment "the artifact is in active development and is not considered ready for formal support from the supplier."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/endOfSupport> a owl:NamedIndividual,
-        ns1:SupportType ;
+        ns2:SupportType ;
     rdfs:label "endOfSupport" ;
     rdfs:comment "there is a defined end of support for the artifact from the supplier.  This may also be referred to as end of life. There is a validUntilDate that can be used to signal when support ends for the artifact."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/limitedSupport> a owl:NamedIndividual,
-        ns1:SupportType ;
+        ns2:SupportType ;
     rdfs:label "limitedSupport" ;
     rdfs:comment "the artifact has been released, and there is limited support available from the supplier. There is a validUntilDate that can provide additional information about the duration of support."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/noAssertion> a owl:NamedIndividual,
-        ns1:SupportType ;
+        ns2:SupportType ;
     rdfs:label "noAssertion" ;
     rdfs:comment "no assertion about the type of support is made.   This is considered the default if no other support type is used."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/noSupport> a owl:NamedIndividual,
-        ns1:SupportType ;
+        ns2:SupportType ;
     rdfs:label "noSupport" ;
     rdfs:comment "there is no support for the artifact from the supplier, consumer assumes any support obligations."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/support> a owl:NamedIndividual,
-        ns1:SupportType ;
+        ns2:SupportType ;
     rdfs:label "support" ;
     rdfs:comment "the artifact has been released, and is supported from the supplier.   There is a validUntilDate that can provide additional information about the duration of support."@en .
 
-ns1:annotationType a owl:ObjectProperty ;
+ns2:annotationType a owl:ObjectProperty ;
     rdfs:comment "Describes the type of annotation."@en ;
-    rdfs:range ns1:AnnotationType .
+    rdfs:range ns2:AnnotationType .
 
-ns1:beginIntegerRange a owl:DatatypeProperty ;
+ns2:beginIntegerRange a owl:DatatypeProperty ;
     rdfs:comment "Defines the beginning of a range."@en ;
     rdfs:range xsd:positiveInteger .
 
-ns1:builtTime a owl:DatatypeProperty ;
+ns2:builtTime a owl:DatatypeProperty ;
     rdfs:comment "Specifies the time an artifact was built."@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns1:completeness a owl:ObjectProperty ;
+ns2:completeness a owl:ObjectProperty ;
     rdfs:comment "Provides information about the completeness of relationships."@en ;
-    rdfs:range ns1:RelationshipCompleteness .
+    rdfs:range ns2:RelationshipCompleteness .
 
-ns1:context a owl:DatatypeProperty ;
+ns2:context a owl:DatatypeProperty ;
     rdfs:comment """Gives information about the circumstances or unifying properties
 that Elements of the bundle have been assembled under."""@en ;
     rdfs:range xsd:string .
 
-ns1:created a owl:DatatypeProperty ;
+ns2:created a owl:DatatypeProperty ;
     rdfs:comment "Identifies when the Element was originally created."@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns1:createdBy a owl:ObjectProperty ;
+ns2:createdBy a owl:ObjectProperty ;
     rdfs:comment "Identifies who or what created the Element."@en ;
-    rdfs:range ns1:Agent .
+    rdfs:range ns2:Agent .
 
-ns1:createdUsing a owl:ObjectProperty ;
+ns2:createdUsing a owl:ObjectProperty ;
     rdfs:comment "Identifies the tooling that was used during the creation of the Element."@en ;
-    rdfs:range ns1:Tool .
+    rdfs:range ns2:Tool .
 
-ns1:creationInfo a owl:ObjectProperty ;
+ns2:creationInfo a owl:ObjectProperty ;
     rdfs:comment "Provides information about the creation of the Element."@en ;
-    rdfs:range ns1:CreationInfo .
+    rdfs:range ns2:CreationInfo .
 
-ns1:dataLicense a owl:ObjectProperty ;
+ns2:dataLicense a owl:ObjectProperty ;
     rdfs:comment """Provides the license under which the SPDX documentation of the Element can be
 used."""@en ;
     rdfs:range <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> .
 
-ns1:definingArtifact a owl:ObjectProperty ;
+ns2:definingArtifact a owl:ObjectProperty ;
     rdfs:comment """Artifact representing a serialization instance of SPDX data containing the
 definition of a particular Element."""@en ;
-    rdfs:range ns1:Artifact .
+    rdfs:range ns2:Artifact .
 
-ns1:description a owl:DatatypeProperty ;
+ns2:description a owl:DatatypeProperty ;
     rdfs:comment "Provides a detailed description of the Element."@en ;
     rdfs:range xsd:string .
 
-ns1:element a owl:ObjectProperty ;
+ns2:element a owl:ObjectProperty ;
     rdfs:comment "Refers to one or more Elements that are part of an ElementCollection."@en ;
-    rdfs:range ns1:Element .
+    rdfs:range ns2:Element .
 
-ns1:endIntegerRange a owl:DatatypeProperty ;
+ns2:endIntegerRange a owl:DatatypeProperty ;
     rdfs:comment "Defines the end of a range."@en ;
     rdfs:range xsd:positiveInteger .
 
-ns1:endTime a owl:DatatypeProperty ;
+ns2:endTime a owl:DatatypeProperty ;
     rdfs:comment "Specifies the time from which an element is no longer applicable / valid."@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns1:extension a owl:ObjectProperty ;
+ns2:extension a owl:ObjectProperty ;
     rdfs:comment "Specifies an Extension characterization of some aspect of an Element."@en ;
     rdfs:range <https://spdx.org/rdf/3.0.1/terms/Extension/Extension> .
 
-ns1:externalIdentifier a owl:ObjectProperty ;
+ns2:externalIdentifier a owl:ObjectProperty ;
     rdfs:comment """Provides a reference to a resource outside the scope of SPDX-3.0 content
 that uniquely identifies an Element."""@en ;
-    rdfs:range ns1:ExternalIdentifier .
+    rdfs:range ns2:ExternalIdentifier .
 
-ns1:externalIdentifierType a owl:ObjectProperty ;
+ns2:externalIdentifierType a owl:ObjectProperty ;
     rdfs:comment "Specifies the type of the external identifier."@en ;
-    rdfs:range ns1:ExternalIdentifierType .
+    rdfs:range ns2:ExternalIdentifierType .
 
-ns1:externalRef a owl:ObjectProperty ;
+ns2:externalRef a owl:ObjectProperty ;
     rdfs:comment """Points to a resource outside the scope of the SPDX-3.0 content
 that provides additional characteristics of an Element."""@en ;
-    rdfs:range ns1:ExternalRef .
+    rdfs:range ns2:ExternalRef .
 
-ns1:externalRefType a owl:ObjectProperty ;
+ns2:externalRefType a owl:ObjectProperty ;
     rdfs:comment "Specifies the type of the external reference."@en ;
-    rdfs:range ns1:ExternalRefType .
+    rdfs:range ns2:ExternalRefType .
 
-ns1:externalSpdxId a owl:DatatypeProperty ;
-    rdfs:comment """Identifies an external Element used within a Document but defined external to
-that Document."""@en ;
+ns2:externalSpdxId a owl:DatatypeProperty ;
+    rdfs:comment """Identifies an external Element used within an SpdxDocument but defined
+external to that SpdxDocument."""@en ;
     rdfs:range xsd:anyURI .
 
-ns1:from a owl:ObjectProperty ;
+ns2:from a owl:ObjectProperty ;
     rdfs:comment "References the Element on the left-hand side of a relationship."@en ;
-    rdfs:range ns1:Element .
+    rdfs:range ns2:Element .
 
-ns1:identifier a owl:DatatypeProperty ;
+ns2:identifier a owl:DatatypeProperty ;
     rdfs:comment "Uniquely identifies an external element."@en ;
     rdfs:range xsd:string .
 
-ns1:identifierLocator a owl:DatatypeProperty ;
+ns2:identifierLocator a owl:DatatypeProperty ;
     rdfs:comment "Provides the location for more information regarding an external identifier."@en ;
     rdfs:range xsd:anyURI .
 
-ns1:import a owl:ObjectProperty ;
+ns2:import a owl:ObjectProperty ;
     rdfs:comment "Provides an ExternalMap of Element identifiers."@en ;
-    rdfs:range ns1:ExternalMap .
+    rdfs:range ns2:ExternalMap .
 
-ns1:issuingAuthority a owl:DatatypeProperty ;
+ns2:issuingAuthority a owl:DatatypeProperty ;
     rdfs:comment "An entity that is authorized to issue identification credentials."@en ;
     rdfs:range xsd:string .
 
-ns1:key a owl:DatatypeProperty ;
+ns2:key a owl:DatatypeProperty ;
     rdfs:comment "A key used in a generic key-value pair."@en ;
     rdfs:range xsd:string .
 
-ns1:locationHint a owl:DatatypeProperty ;
+ns2:locationHint a owl:DatatypeProperty ;
     rdfs:comment "Provides an indication of where to retrieve an external Element."@en ;
     rdfs:range xsd:anyURI .
 
-ns1:locator a owl:DatatypeProperty ;
+ns2:locator a owl:DatatypeProperty ;
     rdfs:comment "Provides the location of an external reference."@en ;
     rdfs:range xsd:string .
 
-ns1:name a owl:DatatypeProperty ;
+ns2:name a owl:DatatypeProperty ;
     rdfs:comment "Identifies the name of an Element as designated by the creator."@en ;
     rdfs:range xsd:string .
 
-ns1:namespace a owl:DatatypeProperty ;
+ns2:namespace a owl:DatatypeProperty ;
     rdfs:comment """Provides an unambiguous mechanism for conveying a URI fragment portion of an
 Element ID."""@en ;
     rdfs:range xsd:anyURI .
 
-ns1:namespaceMap a owl:ObjectProperty ;
+ns2:namespaceMap a owl:ObjectProperty ;
     rdfs:comment "Provides a NamespaceMap of prefixes and associated namespace partial URIs applicable to an SpdxDocument and independent of any specific serialization format or instance."@en ;
-    rdfs:range ns1:NamespaceMap .
+    rdfs:range ns2:NamespaceMap .
 
-ns1:originatedBy a owl:ObjectProperty ;
+ns2:originatedBy a owl:ObjectProperty ;
     rdfs:comment "Identifies from where or whom the Element originally came."@en ;
-    rdfs:range ns1:Agent .
+    rdfs:range ns2:Agent .
 
-ns1:packageVerificationCodeExcludedFile a owl:DatatypeProperty ;
+ns2:packageVerificationCodeExcludedFile a owl:DatatypeProperty ;
     rdfs:comment """The relative file name of a file to be excluded from the
 `PackageVerificationCode`."""@en ;
     rdfs:range xsd:string .
 
-ns1:prefix a owl:DatatypeProperty ;
+ns2:prefix a owl:DatatypeProperty ;
     rdfs:comment "A substitute for a URI."@en ;
     rdfs:range xsd:string .
 
-ns1:profileConformance a owl:ObjectProperty ;
+ns2:profileConformance a owl:ObjectProperty ;
     rdfs:comment """Describes one a profile which the creator of this ElementCollection intends to
 conform to."""@en ;
-    rdfs:range ns1:ProfileIdentifierType .
+    rdfs:range ns2:ProfileIdentifierType .
 
-ns1:relationshipType a owl:ObjectProperty ;
+ns2:relationshipType a owl:ObjectProperty ;
     rdfs:comment "Information about the relationship between two Elements."@en ;
-    rdfs:range ns1:RelationshipType .
+    rdfs:range ns2:RelationshipType .
 
-ns1:releaseTime a owl:DatatypeProperty ;
+ns2:releaseTime a owl:DatatypeProperty ;
     rdfs:comment "Specifies the time an artifact was released."@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns1:rootElement a owl:ObjectProperty ;
+ns2:rootElement a owl:ObjectProperty ;
     rdfs:comment "This property is used to denote the root Element(s) of a tree of elements contained in a BOM."@en ;
-    rdfs:range ns1:Element .
+    rdfs:range ns2:Element .
 
-ns1:scope a owl:ObjectProperty ;
+ns2:scope a owl:ObjectProperty ;
     rdfs:comment "Capture the scope of information about a specific relationship between elements."@en ;
-    rdfs:range ns1:LifecycleScopeType .
+    rdfs:range ns2:LifecycleScopeType .
 
-ns1:specVersion a owl:DatatypeProperty ;
+ns2:specVersion a owl:DatatypeProperty ;
     rdfs:comment """Provides a reference number that can be used to understand how to parse and
 interpret an Element."""@en ;
     rdfs:range xsd:string .
 
-ns1:standardName a owl:DatatypeProperty ;
+ns2:standardName a owl:DatatypeProperty ;
     rdfs:comment "The name of a relevant standard that may apply to an artifact."@en ;
     rdfs:range xsd:string .
 
-ns1:startTime a owl:DatatypeProperty ;
+ns2:startTime a owl:DatatypeProperty ;
     rdfs:comment "Specifies the time from which an element is applicable / valid."@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns1:statement a owl:DatatypeProperty ;
+ns2:statement a owl:DatatypeProperty ;
     rdfs:comment "Commentary on an assertion that an annotator has made."@en ;
     rdfs:range xsd:string .
 
-ns1:subject a owl:ObjectProperty ;
+ns2:subject a owl:ObjectProperty ;
     rdfs:comment "An Element an annotator has made an assertion about."@en ;
-    rdfs:range ns1:Element .
+    rdfs:range ns2:Element .
 
-ns1:summary a owl:DatatypeProperty ;
+ns2:summary a owl:DatatypeProperty ;
     rdfs:comment "A short description of an Element."@en ;
     rdfs:range xsd:string .
 
-ns1:supportLevel a owl:ObjectProperty ;
+ns2:supportLevel a owl:ObjectProperty ;
     rdfs:comment "Specifies the level of support associated with an artifact."@en ;
-    rdfs:range ns1:SupportType .
+    rdfs:range ns2:SupportType .
 
-ns1:to a owl:ObjectProperty ;
+ns2:to a owl:ObjectProperty ;
     rdfs:comment "References an Element on the right-hand side of a relationship."@en ;
-    rdfs:range ns1:Element .
+    rdfs:range ns2:Element .
 
-ns1:validUntilTime a owl:DatatypeProperty ;
+ns2:validUntilTime a owl:DatatypeProperty ;
     rdfs:comment """Specifies until when the artifact can be used before its usage needs to be
 reassessed."""@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns1:value a owl:DatatypeProperty ;
+ns2:value a owl:DatatypeProperty ;
     rdfs:comment "A value used in a generic key-value pair."@en ;
     rdfs:range xsd:string .
 
@@ -1900,7 +1900,7 @@ ns4:datasetUpdateMechanism a owl:DatatypeProperty ;
 
 ns4:hasSensitivePersonalInformation a owl:ObjectProperty ;
     rdfs:comment "Describes if any sensitive personal information is present in the dataset."@en ;
-    rdfs:range ns1:PresenceType .
+    rdfs:range ns2:PresenceType .
 
 ns4:intendedUse a owl:DatatypeProperty ;
     rdfs:comment "Describes what the given dataset should be used for."@en ;
@@ -1912,62 +1912,62 @@ ns4:knownBias a owl:DatatypeProperty ;
 
 ns4:sensor a owl:ObjectProperty ;
     rdfs:comment "Describes a sensor used for collecting the data."@en ;
-    rdfs:range ns1:DictionaryEntry .
+    rdfs:range ns2:DictionaryEntry .
 
-ns3:additionText a owl:DatatypeProperty ;
+ns6:additionText a owl:DatatypeProperty ;
     rdfs:comment "Identifies the full text of a LicenseAddition."@en ;
     rdfs:range xsd:string .
 
-ns3:isDeprecatedAdditionId a owl:DatatypeProperty ;
+ns6:isDeprecatedAdditionId a owl:DatatypeProperty ;
     rdfs:comment "Specifies whether an additional text identifier has been marked as deprecated."@en ;
     rdfs:range xsd:boolean .
 
-ns3:isDeprecatedLicenseId a owl:DatatypeProperty ;
+ns6:isDeprecatedLicenseId a owl:DatatypeProperty ;
     rdfs:comment """Specifies whether a license or additional text identifier has been marked as
 deprecated."""@en ;
     rdfs:range xsd:boolean .
 
-ns3:isFsfLibre a owl:DatatypeProperty ;
+ns6:isFsfLibre a owl:DatatypeProperty ;
     rdfs:comment """Specifies whether the License is listed as free by the
 Free Software Foundation (FSF)."""@en ;
     rdfs:range xsd:boolean .
 
-ns3:isOsiApproved a owl:DatatypeProperty ;
+ns6:isOsiApproved a owl:DatatypeProperty ;
     rdfs:comment """Specifies whether the License is listed as approved by the
 Open Source Initiative (OSI)."""@en ;
     rdfs:range xsd:boolean .
 
-ns3:standardAdditionTemplate a owl:DatatypeProperty ;
+ns6:standardAdditionTemplate a owl:DatatypeProperty ;
     rdfs:comment "Identifies the full text of a LicenseAddition, in SPDX templating format."@en ;
     rdfs:range xsd:string .
 
-ns3:standardLicenseHeader a owl:DatatypeProperty ;
+ns6:standardLicenseHeader a owl:DatatypeProperty ;
     rdfs:comment """Provides a License author's preferred text to indicate that a file is covered
 by the License."""@en ;
     rdfs:range xsd:string .
 
-ns3:standardLicenseTemplate a owl:DatatypeProperty ;
+ns6:standardLicenseTemplate a owl:DatatypeProperty ;
     rdfs:comment "Identifies the full text of a License, in SPDX templating format."@en ;
     rdfs:range xsd:string .
 
-ns3:subjectAddition a owl:ObjectProperty ;
+ns6:subjectAddition a owl:ObjectProperty ;
     rdfs:comment "A LicenseAddition participating in a 'with addition' model."@en ;
-    rdfs:range ns3:LicenseAddition .
+    rdfs:range ns6:LicenseAddition .
 
-ns3:subjectExtendableLicense a owl:ObjectProperty ;
+ns6:subjectExtendableLicense a owl:ObjectProperty ;
     rdfs:comment "A License participating in a 'with addition' model."@en ;
-    rdfs:range ns3:ExtendableLicense .
+    rdfs:range ns6:ExtendableLicense .
 
-ns3:subjectLicense a owl:ObjectProperty ;
+ns6:subjectLicense a owl:ObjectProperty ;
     rdfs:comment "A License participating in an 'or later' model."@en ;
-    rdfs:range ns3:License .
+    rdfs:range ns6:License .
 
 <https://spdx.org/rdf/3.0.1/terms/Extension/cdxPropName> a owl:DatatypeProperty ;
-    rdfs:comment "A name used in a CdxExtension name-value pair."@en ;
+    rdfs:comment "A name used in a CdxPropertyEntry name-value pair."@en ;
     rdfs:range xsd:string .
 
 <https://spdx.org/rdf/3.0.1/terms/Extension/cdxPropValue> a owl:DatatypeProperty ;
-    rdfs:comment "A value used in a CdxExtension name-value pair."@en ;
+    rdfs:comment "A value used in a CdxPropertyEntry name-value pair."@en ;
     rdfs:range xsd:string .
 
 <https://spdx.org/rdf/3.0.1/terms/Extension/cdxProperty> a owl:ObjectProperty ;
@@ -1975,128 +1975,128 @@ ns3:subjectLicense a owl:ObjectProperty ;
     rdfs:range <https://spdx.org/rdf/3.0.1/terms/Extension/CdxPropertyEntry> .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/ExploitCatalogType/kev> a owl:NamedIndividual,
-        ns2:ExploitCatalogType ;
+        ns3:ExploitCatalogType ;
     rdfs:label "kev" ;
     rdfs:comment "CISA's Known Exploited Vulnerability (KEV) Catalog"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/ExploitCatalogType/other> a owl:NamedIndividual,
-        ns2:ExploitCatalogType ;
+        ns3:ExploitCatalogType ;
     rdfs:label "other" ;
     rdfs:comment "Other exploit catalogs"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/SsvcDecisionType/act> a owl:NamedIndividual,
-        ns2:SsvcDecisionType ;
+        ns3:SsvcDecisionType ;
     rdfs:label "act" ;
     rdfs:comment "The vulnerability requires attention from the organization's internal, supervisory-level and leadership-level individuals. Necessary actions include requesting assistance or information about the vulnerability, as well as publishing a notification either internally and/or externally. Typically, internal groups would meet to determine the overall response and then execute agreed upon actions. CISA recommends remediating Act vulnerabilities as soon as possible."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/SsvcDecisionType/attend> a owl:NamedIndividual,
-        ns2:SsvcDecisionType ;
+        ns3:SsvcDecisionType ;
     rdfs:label "attend" ;
     rdfs:comment "The vulnerability requires attention from the organization's internal, supervisory-level individuals. Necessary actions include requesting assistance or information about the vulnerability, and may involve publishing a notification either internally and/or externally. CISA recommends remediating Attend vulnerabilities sooner than standard update timelines."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/SsvcDecisionType/track> a owl:NamedIndividual,
-        ns2:SsvcDecisionType ;
+        ns3:SsvcDecisionType ;
     rdfs:label "track" ;
     rdfs:comment "The vulnerability does not require action at this time. The organization would continue to track the vulnerability and reassess it if new information becomes available. CISA recommends remediating Track vulnerabilities within standard update timelines."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/SsvcDecisionType/trackStar> a owl:NamedIndividual,
-        ns2:SsvcDecisionType ;
+        ns3:SsvcDecisionType ;
     rdfs:label "trackStar" ;
     rdfs:comment "(\"Track\\*\" in the SSVC spec) The vulnerability contains specific characteristics that may require closer monitoring for changes. CISA recommends remediating Track\\* vulnerabilities within standard update timelines."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/VexJustificationType/componentNotPresent> a owl:NamedIndividual,
-        ns2:VexJustificationType ;
+        ns3:VexJustificationType ;
     rdfs:label "componentNotPresent" ;
     rdfs:comment "The software is not affected because the vulnerable component is not in the product."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/VexJustificationType/inlineMitigationsAlreadyExist> a owl:NamedIndividual,
-        ns2:VexJustificationType ;
+        ns3:VexJustificationType ;
     rdfs:label "inlineMitigationsAlreadyExist" ;
     rdfs:comment "Built-in inline controls or mitigations prevent an adversary from leveraging the vulnerability."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/VexJustificationType/vulnerableCodeCannotBeControlledByAdversary> a owl:NamedIndividual,
-        ns2:VexJustificationType ;
+        ns3:VexJustificationType ;
     rdfs:label "vulnerableCodeCannotBeControlledByAdversary" ;
     rdfs:comment "The vulnerable component is present, and the component contains the vulnerable code. However, vulnerable code is used in such a way that an attacker cannot mount any anticipated attack."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/VexJustificationType/vulnerableCodeNotInExecutePath> a owl:NamedIndividual,
-        ns2:VexJustificationType ;
+        ns3:VexJustificationType ;
     rdfs:label "vulnerableCodeNotInExecutePath" ;
     rdfs:comment "The affected code is not reachable through the execution of the code, including non-anticipated states of the product."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/VexJustificationType/vulnerableCodeNotPresent> a owl:NamedIndividual,
-        ns2:VexJustificationType ;
+        ns3:VexJustificationType ;
     rdfs:label "vulnerableCodeNotPresent" ;
     rdfs:comment "The product is not affected because the code underlying the vulnerability is not present in the product."@en .
 
-ns2:actionStatement a owl:DatatypeProperty ;
+ns3:actionStatement a owl:DatatypeProperty ;
     rdfs:comment """Provides advise on how to mitigate or remediate a vulnerability when a VEX product
 is affected by it."""@en ;
     rdfs:range xsd:string .
 
-ns2:actionStatementTime a owl:DatatypeProperty ;
+ns3:actionStatementTime a owl:DatatypeProperty ;
     rdfs:comment """Records the time when a recommended action was communicated in a VEX statement
 to mitigate a vulnerability."""@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns2:assessedElement a owl:ObjectProperty ;
+ns3:assessedElement a owl:ObjectProperty ;
     rdfs:comment """Specifies an Element contained in a piece of software where a vulnerability was
 found."""@en ;
-    rdfs:range ns1:Element .
+    rdfs:range ns2:Element .
 
-ns2:catalogType a owl:ObjectProperty ;
+ns3:catalogType a owl:ObjectProperty ;
     rdfs:comment "Specifies the exploit catalog type."@en ;
-    rdfs:range ns2:ExploitCatalogType .
+    rdfs:range ns3:ExploitCatalogType .
 
-ns2:decisionType a owl:ObjectProperty ;
+ns3:decisionType a owl:ObjectProperty ;
     rdfs:comment """Provide the enumeration of possible decisions in the
 [Stakeholder-Specific Vulnerability Categorization (SSVC) decision tree](https://www.cisa.gov/stakeholder-specific-vulnerability-categorization-ssvc)."""@en ;
-    rdfs:range ns2:SsvcDecisionType .
+    rdfs:range ns3:SsvcDecisionType .
 
-ns2:exploited a owl:DatatypeProperty ;
+ns3:exploited a owl:DatatypeProperty ;
     rdfs:comment "Describe that a CVE is known to have an exploit because it's been listed in an exploit catalog."@en ;
     rdfs:range xsd:boolean .
 
-ns2:impactStatement a owl:DatatypeProperty ;
+ns3:impactStatement a owl:DatatypeProperty ;
     rdfs:comment """Explains why a VEX product is not affected by a vulnerability. It is an
 alternative in VexNotAffectedVulnAssessmentRelationship to the machine-readable
 justification label."""@en ;
     rdfs:range xsd:string .
 
-ns2:impactStatementTime a owl:DatatypeProperty ;
+ns3:impactStatementTime a owl:DatatypeProperty ;
     rdfs:comment "Timestamp of impact statement."@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns2:justificationType a owl:ObjectProperty ;
+ns3:justificationType a owl:ObjectProperty ;
     rdfs:comment """Impact justification label to be used when linking a vulnerability to an element
 representing a VEX product with a VexNotAffectedVulnAssessmentRelationship
 relationship."""@en ;
-    rdfs:range ns2:VexJustificationType .
+    rdfs:range ns3:VexJustificationType .
 
-ns2:locator a owl:DatatypeProperty ;
+ns3:locator a owl:DatatypeProperty ;
     rdfs:comment "Provides the location of an exploit catalog."@en ;
     rdfs:range xsd:anyURI .
 
-ns2:percentile a owl:DatatypeProperty ;
+ns3:percentile a owl:DatatypeProperty ;
     rdfs:comment "The percentile of the current probability score."@en ;
     rdfs:range xsd:decimal .
 
-ns2:probability a owl:DatatypeProperty ;
+ns3:probability a owl:DatatypeProperty ;
     rdfs:comment "A probability score between 0 and 1 of a vulnerability being exploited."@en ;
     rdfs:range xsd:decimal .
 
-ns2:statusNotes a owl:DatatypeProperty ;
+ns3:statusNotes a owl:DatatypeProperty ;
     rdfs:comment "Conveys information about how VEX status was determined."@en ;
     rdfs:range xsd:string .
 
-ns2:vexVersion a owl:DatatypeProperty ;
+ns3:vexVersion a owl:DatatypeProperty ;
     rdfs:comment "Specifies the version of a VEX statement."@en ;
     rdfs:range xsd:string .
 
 <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/customIdToUri> a owl:ObjectProperty ;
     rdfs:comment """Maps a LicenseRef or AdditionRef string for a Custom License or a Custom
 License Addition to its URI ID."""@en ;
-    rdfs:range ns1:DictionaryEntry .
+    rdfs:range ns2:DictionaryEntry .
 
 <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/licenseExpression> a owl:DatatypeProperty ;
     rdfs:comment "A string in the license expression format."@en ;
@@ -2107,391 +2107,374 @@ License Addition to its URI ID."""@en ;
     rdfs:range xsd:string .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/ContentIdentifierType/gitoid> a owl:NamedIndividual,
-        ns5:ContentIdentifierType ;
+        ns1:ContentIdentifierType ;
     rdfs:label "gitoid" ;
     rdfs:comment "[Gitoid](https://www.iana.org/assignments/uri-schemes/prov/gitoid), stands for [Git Object ID](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects). A gitoid of type blob is a unique hash of a binary artifact. A gitoid may represent either an [Artifact Identifier](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#artifact-identifier-types) for the software artifact or an [Input Manifest Identifier](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#input-manifest-identifier) for the software artifact's associated [Artifact Input Manifest](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#artifact-input-manifest); this ambiguity exists because the Artifact Input Manifest is itself an artifact, and the gitoid of that artifact is its valid identifier. Gitoids calculated on software artifacts (Snippet, File, or Package Elements) should be recorded in the SPDX 3.0 SoftwareArtifact's contentIdentifier property. Gitoids calculated on the Artifact Input Manifest (Input Manifest Identifier) should be recorded in the SPDX 3.0 Element's externalIdentifier property. See [OmniBOR Specification](https://github.com/omnibor/spec/), a minimalistic specification for describing software [Artifact Dependency Graphs](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#artifact-dependency-graph-adg)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/ContentIdentifierType/swhid> a owl:NamedIndividual,
-        ns5:ContentIdentifierType ;
+        ns1:ContentIdentifierType ;
     rdfs:label "swhid" ;
     rdfs:comment "SoftWare Hash IDentifier, a persistent intrinsic identifier for digital artifacts, such as files, trees (also known as directories or folders), commits, and other objects typically found in version control systems. The format of the identifiers is defined in the [SWHID specification](https://www.swhid.org/specification/v1.1/4.Syntax) (ISO/IEC DIS 18670). They typically look like `swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2`."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/FileKindType/directory> a owl:NamedIndividual,
-        ns5:FileKindType ;
+        ns1:FileKindType ;
     rdfs:label "directory" ;
     rdfs:comment "The file represents a directory and all content stored in that directory."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/FileKindType/file> a owl:NamedIndividual,
-        ns5:FileKindType ;
+        ns1:FileKindType ;
     rdfs:label "file" ;
     rdfs:comment "The file represents a single file (default)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SbomType/analyzed> a owl:NamedIndividual,
-        ns5:SbomType ;
+        ns1:SbomType ;
     rdfs:label "analyzed" ;
     rdfs:comment "SBOM generated through analysis of artifacts (e.g., executables, packages, containers, and virtual machine images) after its build. Such analysis generally requires a variety of heuristics. In some contexts, this may also be referred to as a \"3rd party\" SBOM."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SbomType/build> a owl:NamedIndividual,
-        ns5:SbomType ;
+        ns1:SbomType ;
     rdfs:label "build" ;
     rdfs:comment "SBOM generated as part of the process of building the software to create a releasable artifact (e.g., executable or package) from data such as source files, dependencies, built components, build process ephemeral data, and other SBOMs."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SbomType/deployed> a owl:NamedIndividual,
-        ns5:SbomType ;
+        ns1:SbomType ;
     rdfs:label "deployed" ;
     rdfs:comment "SBOM provides an inventory of software that is present on a system. This may be an assembly of other SBOMs that combines analysis of configuration options, and examination of execution behavior in a (potentially simulated) deployment environment."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SbomType/design> a owl:NamedIndividual,
-        ns5:SbomType ;
+        ns1:SbomType ;
     rdfs:label "design" ;
     rdfs:comment "SBOM of intended, planned software project or product with included components (some of which may not yet exist) for a new software artifact."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SbomType/runtime> a owl:NamedIndividual,
-        ns5:SbomType ;
+        ns1:SbomType ;
     rdfs:label "runtime" ;
     rdfs:comment "SBOM generated through instrumenting the system running the software, to capture only components present in the system, as well as external call-outs or dynamically loaded components. In some contexts, this may also be referred to as an \"Instrumented\" or \"Dynamic\" SBOM."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SbomType/source> a owl:NamedIndividual,
-        ns5:SbomType ;
+        ns1:SbomType ;
     rdfs:label "source" ;
     rdfs:comment "SBOM created directly from the development environment, source files, and included dependencies used to build an product artifact."@en .
 
-ns5:additionalPurpose a owl:ObjectProperty ;
+ns1:additionalPurpose a owl:ObjectProperty ;
     rdfs:comment "Provides additional purpose information of the software artifact."@en ;
-    rdfs:range ns5:SoftwarePurpose .
+    rdfs:range ns1:SoftwarePurpose .
 
-ns5:attributionText a owl:DatatypeProperty ;
+ns1:attributionText a owl:DatatypeProperty ;
     rdfs:comment """Provides a place for the SPDX data creator to record acknowledgement text for
 a software Package, File or Snippet."""@en ;
     rdfs:range xsd:string .
 
-ns5:byteRange a owl:DatatypeProperty ;
+ns1:byteRange a owl:DatatypeProperty ;
     rdfs:comment """Defines the byte range in the original host file that the snippet information
 applies to."""@en ;
-    rdfs:range ns1:PositiveIntegerRange .
+    rdfs:range ns2:PositiveIntegerRange .
 
-ns5:contentIdentifier a owl:DatatypeProperty ;
+ns1:contentIdentifier a owl:DatatypeProperty ;
     rdfs:comment """A canonical, unique, immutable identifier of the artifact content, that may be
 used for verifying its identity and/or integrity."""@en ;
-    rdfs:range ns5:ContentIdentifier .
+    rdfs:range ns1:ContentIdentifier .
 
-ns5:contentIdentifierType a owl:ObjectProperty ;
+ns1:contentIdentifierType a owl:ObjectProperty ;
     rdfs:comment "Specifies the type of the content identifier."@en ;
-    rdfs:range ns5:ContentIdentifierType .
+    rdfs:range ns1:ContentIdentifierType .
 
-ns5:contentIdentifierValue a owl:DatatypeProperty ;
+ns1:contentIdentifierValue a owl:DatatypeProperty ;
     rdfs:comment "Specifies the value of the content identifier."@en ;
     rdfs:range xsd:anyURI .
 
-ns5:copyrightText a owl:DatatypeProperty ;
+ns1:copyrightText a owl:DatatypeProperty ;
     rdfs:comment """Identifies the text of one or more copyright notices for a software Package,
 File or Snippet, if any."""@en ;
     rdfs:range xsd:string .
 
-ns5:downloadLocation a owl:DatatypeProperty ;
+ns1:downloadLocation a owl:DatatypeProperty ;
     rdfs:comment """Identifies the download Uniform Resource Identifier for the package at the time
 that the document was created."""@en ;
     rdfs:range xsd:anyURI .
 
-ns5:fileKind a owl:ObjectProperty ;
+ns1:fileKind a owl:ObjectProperty ;
     rdfs:comment "Describes if a given file is a directory or non-directory kind of file."@en ;
-    rdfs:range ns5:FileKindType .
+    rdfs:range ns1:FileKindType .
 
-ns5:homePage a owl:DatatypeProperty ;
+ns1:homePage a owl:DatatypeProperty ;
     rdfs:comment """A place for the SPDX document creator to record a website that serves as the
 package's home page."""@en ;
     rdfs:range xsd:anyURI .
 
-ns5:lineRange a owl:DatatypeProperty ;
+ns1:lineRange a owl:DatatypeProperty ;
     rdfs:comment """Defines the line range in the original host file that the snippet information
 applies to."""@en ;
-    rdfs:range ns1:PositiveIntegerRange .
+    rdfs:range ns2:PositiveIntegerRange .
 
-ns5:packageUrl a owl:DatatypeProperty ;
+ns1:packageUrl a owl:DatatypeProperty ;
     rdfs:comment """Provides a place for the SPDX data creator to record the package URL string
 (in accordance with the Package URL specification) for a software Package."""@en ;
     rdfs:range xsd:anyURI .
 
-ns5:packageVersion a owl:DatatypeProperty ;
+ns1:packageVersion a owl:DatatypeProperty ;
     rdfs:comment "Identify the version of a package."@en ;
     rdfs:range xsd:string .
 
-ns5:primaryPurpose a owl:ObjectProperty ;
+ns1:primaryPurpose a owl:ObjectProperty ;
     rdfs:comment "Provides information about the primary purpose of the software artifact."@en ;
-    rdfs:range ns5:SoftwarePurpose .
+    rdfs:range ns1:SoftwarePurpose .
 
-ns5:sbomType a owl:ObjectProperty ;
+ns1:sbomType a owl:ObjectProperty ;
     rdfs:comment "Provides information about the type of an SBOM."@en ;
-    rdfs:range ns5:SbomType .
+    rdfs:range ns1:SbomType .
 
-ns5:snippetFromFile a owl:ObjectProperty ;
+ns1:snippetFromFile a owl:ObjectProperty ;
     rdfs:comment "Defines the original host file that the snippet information applies to."@en ;
-    rdfs:range ns5:File .
+    rdfs:range ns1:File .
 
-ns5:sourceInfo a owl:DatatypeProperty ;
+ns1:sourceInfo a owl:DatatypeProperty ;
     rdfs:comment """Records any relevant background information or additional comments
 about the origin of the package."""@en ;
     rdfs:range xsd:string .
 
-ns6:EnergyConsumption a owl:Class,
+ns5:EnergyConsumption a owl:Class,
         sh:NodeShape ;
     rdfs:comment """A class for describing the energy consumption incurred by an AI model in
 different stages of its lifecycle."""@en ;
     sh:nodeKind sh:BlankNode ;
-    sh:property [ sh:class ns6:EnergyConsumptionDescription ;
+    sh:property [ sh:class ns5:EnergyConsumptionDescription ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns6:inferenceEnergyConsumption ],
-        [ sh:class ns6:EnergyConsumptionDescription ;
+            sh:path ns5:finetuningEnergyConsumption ],
+        [ sh:class ns5:EnergyConsumptionDescription ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns6:finetuningEnergyConsumption ],
-        [ sh:class ns6:EnergyConsumptionDescription ;
+            sh:path ns5:trainingEnergyConsumption ],
+        [ sh:class ns5:EnergyConsumptionDescription ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns6:trainingEnergyConsumption ] .
+            sh:path ns5:inferenceEnergyConsumption ] .
 
-ns1:CreationInfo a owl:Class,
+ns2:CreationInfo a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Provides information about the creation of the Element."@en ;
     sh:nodeKind sh:BlankNode ;
-    sh:property [ sh:datatype xsd:dateTimeStamp ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:comment ],
+        [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:created ;
+            sh:path ns2:created ;
             sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:comment ],
-        [ sh:class ns1:Tool ;
+        [ sh:class ns2:Tool ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:createdUsing ],
-        [ sh:class ns1:Agent ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:createdBy ],
+            sh:path ns2:createdUsing ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:specVersion ;
-            sh:pattern "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$" ] .
+            sh:path ns2:specVersion ;
+            sh:pattern "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$" ],
+        [ sh:class ns2:Agent ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns2:createdBy ] .
 
-ns1:ElementCollection a ns7:AbstractClass,
-        owl:Class,
-        sh:NodeShape ;
-    rdfs:comment "A collection of Elements, not necessarily with unifying context."@en ;
-    rdfs:subClassOf ns1:Element ;
-    sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:ProfileIdentifierType ;
-            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/core> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/software> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/simpleLicensing> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/expandedLicensing> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/security> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/build> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/ai> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/dataset> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/extension> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/lite> ) ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:profileConformance ],
-        [ sh:class ns1:Element ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:element ],
-        [ sh:class ns1:Element ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:rootElement ] .
-
-ns1:ExternalIdentifier a owl:Class,
+ns2:ExternalIdentifier a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A reference to a resource identifier defined outside the scope of SPDX-3.0 content that uniquely identifies an Element."@en ;
     sh:nodeKind sh:BlankNode ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:comment ],
-        [ sh:datatype xsd:anyURI ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:identifierLocator ],
+            sh:path ns2:comment ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:identifier ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
+            sh:path ns2:identifier ],
+        [ sh:datatype xsd:anyURI ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:issuingAuthority ],
-        [ sh:class ns1:ExternalIdentifierType ;
+            sh:path ns2:identifierLocator ],
+        [ sh:class ns2:ExternalIdentifierType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/cpe22> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/cpe23> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/cve> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/email> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/gitoid> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/other> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/packageUrl> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/securityOther> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/swhid> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/swid> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/urlScheme> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:externalIdentifierType ] .
+            sh:path ns2:externalIdentifierType ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:issuingAuthority ] .
 
-ns1:ExternalMap a owl:Class,
+ns2:ExternalMap a owl:Class,
         sh:NodeShape ;
-    rdfs:comment """A map of Element identifiers that are used within a Document but defined
-external to that Document."""@en ;
+    rdfs:comment """A map of Element identifiers that are used within an SpdxDocument but defined
+external to that SpdxDocument."""@en ;
     sh:nodeKind sh:BlankNode ;
-    sh:property [ sh:datatype xsd:anyURI ;
+    sh:property [ sh:class ns2:IntegrityMethod ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns2:verifiedUsing ],
+        [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:externalSpdxId ],
-        [ sh:class ns1:IntegrityMethod ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:verifiedUsing ],
-        [ sh:class ns1:Artifact ;
+            sh:path ns2:externalSpdxId ],
+        [ sh:class ns2:Artifact ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:definingArtifact ],
+            sh:path ns2:definingArtifact ],
         [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:locationHint ] .
+            sh:path ns2:locationHint ] .
 
-ns1:ExternalRef a owl:Class,
+ns2:ExternalRef a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A reference to a resource outside the scope of SPDX-3.0 content related to an Element."@en ;
     sh:nodeKind sh:BlankNode ;
     sh:property [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:locator ],
-        [ sh:class ns1:ExternalRefType ;
-            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/altDownloadLocation> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/altWebPage> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/binaryArtifact> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/bower> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/buildMeta> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/buildSystem> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/chat> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/certificationReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/componentAnalysisReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/cwe> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/documentation> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/dynamicAnalysisReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/eolNotice> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/exportControlAssessment> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/funding> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/issueTracker> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/mailingList> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/mavenCentral> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/metrics> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/npm> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/nuget> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/license> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/other> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/privacyAssessment> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/productMetadata> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/purchaseOrder> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/qualityAssessmentReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/releaseNotes> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/releaseHistory> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/riskAssessment> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/runtimeAnalysisReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/secureSoftwareAttestation> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityAdvisory> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityAdversaryModel> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityFix> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityOther> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityPenTestReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityPolicy> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityThreatModel> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/socialMedia> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/sourceArtifact> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/staticAnalysisReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/support> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/vcs> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/vulnerabilityDisclosureReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/vulnerabilityExploitabilityAssessment> ) ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:externalRefType ],
+            sh:path ns2:locator ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:contentType ;
+            sh:path ns2:contentType ;
             sh:pattern "^[^\\/]+\\/[^\\/]+$" ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:comment ] .
+            sh:path ns2:comment ],
+        [ sh:class ns2:ExternalRefType ;
+            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/altDownloadLocation> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/altWebPage> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/binaryArtifact> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/bower> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/buildMeta> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/buildSystem> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/chat> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/certificationReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/componentAnalysisReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/cwe> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/documentation> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/dynamicAnalysisReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/eolNotice> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/exportControlAssessment> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/funding> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/issueTracker> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/mailingList> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/mavenCentral> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/metrics> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/npm> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/nuget> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/license> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/other> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/privacyAssessment> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/productMetadata> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/purchaseOrder> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/qualityAssessmentReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/releaseNotes> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/releaseHistory> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/riskAssessment> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/runtimeAnalysisReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/secureSoftwareAttestation> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityAdvisory> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityAdversaryModel> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityFix> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityOther> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityPenTestReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityPolicy> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/securityThreatModel> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/socialMedia> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/sourceArtifact> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/staticAnalysisReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/support> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/vcs> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/vulnerabilityDisclosureReport> <https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/vulnerabilityExploitabilityAssessment> ) ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns2:externalRefType ] .
 
-ns1:Hash a owl:Class,
+ns2:Hash a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A mathematically calculated representation of a grouping of data."@en ;
-    rdfs:subClassOf ns1:IntegrityMethod ;
+    rdfs:subClassOf ns2:IntegrityMethod ;
     sh:nodeKind sh:BlankNode ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:hashValue ],
-        [ sh:class ns1:HashAlgorithm ;
+            sh:path ns2:hashValue ],
+        [ sh:class ns2:HashAlgorithm ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/adler32> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/blake2b256> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/blake2b384> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/blake2b512> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/blake3> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/crystalsDilithium> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/crystalsKyber> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/falcon> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/md2> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/md4> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/md5> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/md6> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/other> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha1> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha224> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha256> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha384> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha512> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha3_224> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha3_256> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha3_384> <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha3_512> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:algorithm ] .
+            sh:path ns2:algorithm ] .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/adler32> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "adler32" ;
-    rdfs:comment "Adler-32 checksum is part of the widely used zlib compression library as defined in [RFC 1950](https://www.rfc-editor.org/info/rfc1950) Section 2.3."@en .
+    rdfs:comment "Adler-32 checksum is part of the widely used zlib compression library as defined in [RFC 1950](https://datatracker.ietf.org/doc/rfc1950/) Section 2.3."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/blake2b256> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "blake2b256" ;
-    rdfs:comment "BLAKE2b algorithm with a digest size of 256, as defined in [RFC 7693](https://www.rfc-editor.org/info/rfc7693) Section 4."@en .
+    rdfs:comment "BLAKE2b algorithm with a digest size of 256, as defined in [RFC 7693](https://datatracker.ietf.org/doc/rfc7693/) Section 4."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/blake2b384> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "blake2b384" ;
-    rdfs:comment "BLAKE2b algorithm with a digest size of 384, as defined in [RFC 7693](https://www.rfc-editor.org/info/rfc7693) Section 4."@en .
+    rdfs:comment "BLAKE2b algorithm with a digest size of 384, as defined in [RFC 7693](https://datatracker.ietf.org/doc/rfc7693/) Section 4."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/blake2b512> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "blake2b512" ;
-    rdfs:comment "BLAKE2b algorithm with a digest size of 512, as defined in [RFC 7693](https://www.rfc-editor.org/info/rfc7693) Section 4."@en .
+    rdfs:comment "BLAKE2b algorithm with a digest size of 512, as defined in [RFC 7693](https://datatracker.ietf.org/doc/rfc7693/) Section 4."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/blake3> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "blake3" ;
     rdfs:comment "[BLAKE3](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf)"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/crystalsDilithium> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "crystalsDilithium" ;
     rdfs:comment "[Dilithium](https://pq-crystals.org/dilithium/)"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/crystalsKyber> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "crystalsKyber" ;
     rdfs:comment "[Kyber](https://pq-crystals.org/kyber/)"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/falcon> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "falcon" ;
     rdfs:comment "[FALCON](https://falcon-sign.info/falcon.pdf)"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/md2> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "md2" ;
-    rdfs:comment "MD2 message-digest algorithm, as defined in [RFC 1319](https://www.rfc-editor.org/info/rfc1319/)."@en .
+    rdfs:comment "MD2 message-digest algorithm, as defined in [RFC 1319](https://datatracker.ietf.org/doc/rfc1319/)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/md4> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "md4" ;
-    rdfs:comment "MD4 message-digest algorithm, as defined in [RFC 1186](https://www.rfc-editor.org/info/rfc1186)."@en .
+    rdfs:comment "MD4 message-digest algorithm, as defined in [RFC 1186](https://datatracker.ietf.org/doc/rfc1186/)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/md5> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "md5" ;
-    rdfs:comment "MD5 message-digest algorithm, as defined in [RFC 1321](https://www.rfc-editor.org/info/rfc1321)."@en .
+    rdfs:comment "MD5 message-digest algorithm, as defined in [RFC 1321](https://datatracker.ietf.org/doc/rfc1321/)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/md6> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "md6" ;
     rdfs:comment "[MD6 hash function](https://people.csail.mit.edu/rivest/pubs/RABCx08.pdf)"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/other> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "other" ;
     rdfs:comment "any hashing algorithm that does not exist in this list of entries"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha1> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "sha1" ;
-    rdfs:comment "SHA-1, a secure hashing algorithm, as defined in [RFC 3174](https://www.rfc-editor.org/info/rfc3174)."@en .
+    rdfs:comment "SHA-1, a secure hashing algorithm, as defined in [RFC 3174](https://datatracker.ietf.org/doc/rfc3174/)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha224> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "sha224" ;
-    rdfs:comment "SHA-2 with a digest length of 224, as defined in [RFC 3874](https://www.rfc-editor.org/info/rfc3874)."@en .
+    rdfs:comment "SHA-2 with a digest length of 224, as defined in [RFC 3874](https://datatracker.ietf.org/doc/rfc3874/)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha256> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "sha256" ;
-    rdfs:comment "SHA-2 with a digest length of 256, as defined in [RFC 6234](https://www.rfc-editor.org/info/rfc6234)."@en .
+    rdfs:comment "SHA-2 with a digest length of 256, as defined in [RFC 6234](https://datatracker.ietf.org/doc/rfc6234/)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha384> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "sha384" ;
-    rdfs:comment "SHA-2 with a digest length of 384, as defined in [RFC 6234](https://www.rfc-editor.org/info/rfc6234)."@en .
+    rdfs:comment "SHA-2 with a digest length of 384, as defined in [RFC 6234](https://datatracker.ietf.org/doc/rfc6234/)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha3_224> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "sha3_224" ;
     rdfs:comment "SHA-3 with a digest length of 224, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha3_256> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "sha3_256" ;
     rdfs:comment "SHA-3 with a digest length of 256, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha3_384> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "sha3_384" ;
     rdfs:comment "SHA-3 with a digest length of 384, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha3_512> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "sha3_512" ;
     rdfs:comment "SHA-3 with a digest length of 512, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/sha512> a owl:NamedIndividual,
-        ns1:HashAlgorithm ;
+        ns2:HashAlgorithm ;
     rdfs:label "sha512" ;
-    rdfs:comment "SHA-2 with a digest length of 512, as defined in [RFC 6234](https://www.rfc-editor.org/info/rfc6234)."@en .
+    rdfs:comment "SHA-2 with a digest length of 512, as defined in [RFC 6234](https://datatracker.ietf.org/doc/rfc6234/)."@en .
 
-ns1:NamespaceMap a owl:Class,
+ns2:NamespaceMap a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A mapping between prefixes and namespace partial URIs."@en ;
     sh:nodeKind sh:BlankNode ;
@@ -2499,97 +2482,103 @@ ns1:NamespaceMap a owl:Class,
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:prefix ],
+            sh:path ns2:prefix ],
         [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:namespace ] .
+            sh:path ns2:namespace ] .
 
-ns1:Relationship a owl:Class,
+ns2:Relationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Describes a relationship between one or more elements."@en ;
-    rdfs:subClassOf ns1:Element ;
+    rdfs:subClassOf ns2:Element ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:RelationshipType ;
+    sh:property [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:endTime ;
+            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+        [ sh:class ns2:Element ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns2:to ],
+        [ sh:class ns2:Element ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns2:from ],
+        [ sh:class ns2:RelationshipType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/affects> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/amendedBy> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/ancestorOf> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/availableFrom> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/configures> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/contains> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/coordinatedBy> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/copiedTo> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/delegatedTo> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/dependsOn> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/descendantOf> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/describes> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/doesNotAffect> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/expandsTo> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/exploitCreatedBy> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/fixedBy> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/fixedIn> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/foundBy> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/generates> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasAddedFile> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasAssessmentFor> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasAssociatedVulnerability> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasConcludedLicense> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDataFile> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDeclaredLicense> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDeletedFile> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDependencyManifest> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDistributionArtifact> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDocumentation> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasDynamicLink> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasEvidence> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasExample> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasHost> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasInput> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasMetadata> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasOptionalComponent> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasOptionalDependency> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasOutput> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasPrerequisite> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasProvidedDependency> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasRequirement> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasSpecification> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasStaticLink> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasTest> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasTestCase> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/hasVariant> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/invokedBy> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/modifiedBy> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/other> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/packagedBy> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/patchedBy> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/publishedBy> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/reportedBy> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/republishedBy> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/serializedInArtifact> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/testedOn> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/trainedOn> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/underInvestigationFor> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/usesTool> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:relationshipType ],
-        [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:endTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:class ns1:Element ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:to ],
-        [ sh:class ns1:Element ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:from ],
-        [ sh:class ns1:RelationshipCompleteness ;
+            sh:path ns2:relationshipType ],
+        [ sh:class ns2:RelationshipCompleteness ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipCompleteness/incomplete> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipCompleteness/complete> <https://spdx.org/rdf/3.0.1/terms/Core/RelationshipCompleteness/noAssertion> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:completeness ],
+            sh:path ns2:completeness ],
         [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:startTime ;
+            sh:path ns2:startTime ;
             sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ] .
 
-ns1:Tool a owl:Class ;
+ns2:Tool a owl:Class ;
     rdfs:comment "An element of hardware and/or software utilized to carry out a particular function."@en ;
-    rdfs:subClassOf ns1:Element ;
+    rdfs:subClassOf ns2:Element ;
     sh:nodeKind sh:IRI .
 
-ns1:algorithm a owl:ObjectProperty ;
+ns2:algorithm a owl:ObjectProperty ;
     rdfs:comment "Specifies the algorithm used for calculating the hash value."@en ;
-    rdfs:range ns1:HashAlgorithm .
+    rdfs:range ns2:HashAlgorithm .
 
-ns1:hashValue a owl:DatatypeProperty ;
+ns2:hashValue a owl:DatatypeProperty ;
     rdfs:comment "The result of applying a hash algorithm to an Element."@en ;
     rdfs:range xsd:string .
 
-ns1:suppliedBy a owl:ObjectProperty ;
+ns2:suppliedBy a owl:ObjectProperty ;
     rdfs:comment """Identifies who or what supplied the artifact or VulnAssessmentRelationship
 referenced by the Element."""@en ;
-    rdfs:range ns1:Agent .
+    rdfs:range ns2:Agent .
 
-ns1:verifiedUsing a owl:ObjectProperty ;
+ns2:verifiedUsing a owl:ObjectProperty ;
     rdfs:comment """Provides an IntegrityMethod with which the integrity of an Element can be
 asserted."""@en ;
-    rdfs:range ns1:IntegrityMethod .
+    rdfs:range ns2:IntegrityMethod .
 
-ns3:deprecatedVersion a owl:DatatypeProperty ;
+ns6:IndividualLicensingInfo a owl:Class ;
+    rdfs:comment """A concrete subclass of AnyLicenseInfo used by Individuals in the
+ExpandedLicensing profile."""@en ;
+    rdfs:subClassOf <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> ;
+    sh:nodeKind sh:IRI .
+
+ns6:deprecatedVersion a owl:DatatypeProperty ;
     rdfs:comment """Specifies the SPDX License List version in which this license or exception
 identifier was deprecated."""@en ;
     rdfs:range xsd:string .
 
-ns3:licenseXml a owl:DatatypeProperty ;
+ns6:licenseXml a owl:DatatypeProperty ;
     rdfs:comment """Identifies all the text and metadata associated with a license in the license
 XML format."""@en ;
     rdfs:range xsd:string .
 
-ns3:listVersionAdded a owl:DatatypeProperty ;
+ns6:listVersionAdded a owl:DatatypeProperty ;
     rdfs:comment """Specifies the SPDX License List version in which this ListedLicense or
 ListedLicenseException identifier was first added."""@en ;
     rdfs:range xsd:string .
 
-ns3:member a owl:ObjectProperty ;
+ns6:member a owl:ObjectProperty ;
     rdfs:comment "A license expression participating in a license set."@en ;
     rdfs:range <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> .
 
-ns3:obsoletedBy a owl:DatatypeProperty ;
+ns6:obsoletedBy a owl:DatatypeProperty ;
     rdfs:comment """Specifies the licenseId that is preferred to be used in place of a deprecated
 License or LicenseAddition."""@en ;
     rdfs:range xsd:string .
 
-ns3:seeAlso a owl:DatatypeProperty ;
+ns6:seeAlso a owl:DatatypeProperty ;
     rdfs:comment "Contains a URL where the License or LicenseAddition can be found in use."@en ;
     rdfs:range xsd:anyURI .
 
@@ -2608,43 +2597,43 @@ ns3:seeAlso a owl:DatatypeProperty ;
             sh:path <https://spdx.org/rdf/3.0.1/terms/Extension/cdxPropName> ] .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/critical> a owl:NamedIndividual,
-        ns2:CvssSeverityType ;
+        ns3:CvssSeverityType ;
     rdfs:label "critical" ;
     rdfs:comment "When a CVSS score is between 9.0 - 10.0"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/high> a owl:NamedIndividual,
-        ns2:CvssSeverityType ;
+        ns3:CvssSeverityType ;
     rdfs:label "high" ;
     rdfs:comment "When a CVSS score is between 7.0 - 8.9"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/low> a owl:NamedIndividual,
-        ns2:CvssSeverityType ;
+        ns3:CvssSeverityType ;
     rdfs:label "low" ;
     rdfs:comment "When a CVSS score is between 0.1 - 3.9"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/medium> a owl:NamedIndividual,
-        ns2:CvssSeverityType ;
+        ns3:CvssSeverityType ;
     rdfs:label "medium" ;
     rdfs:comment "When a CVSS score is between 4.0 - 6.9"@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/none> a owl:NamedIndividual,
-        ns2:CvssSeverityType ;
+        ns3:CvssSeverityType ;
     rdfs:label "none" ;
     rdfs:comment "When a CVSS score is 0.0"@en .
 
-ns2:modifiedTime a owl:DatatypeProperty ;
+ns3:modifiedTime a owl:DatatypeProperty ;
     rdfs:comment "Specifies a time when a vulnerability assessment was modified"@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns2:publishedTime a owl:DatatypeProperty ;
+ns3:publishedTime a owl:DatatypeProperty ;
     rdfs:comment "Specifies the time when a vulnerability was published."@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns2:severity a owl:ObjectProperty ;
+ns3:severity a owl:ObjectProperty ;
     rdfs:comment "Specifies the CVSS qualitative severity rating of a vulnerability in relation to a piece of software."@en ;
-    rdfs:range ns2:CvssSeverityType .
+    rdfs:range ns3:CvssSeverityType .
 
-ns2:withdrawnTime a owl:DatatypeProperty ;
+ns3:withdrawnTime a owl:DatatypeProperty ;
     rdfs:comment "Specified the time and date when a vulnerability was withdrawn."@en ;
     rdfs:range xsd:dateTimeStamp .
 
@@ -2652,309 +2641,260 @@ ns2:withdrawnTime a owl:DatatypeProperty ;
     rdfs:comment "Identifies the full text of a License or Addition."@en ;
     rdfs:range xsd:string .
 
-ns5:ContentIdentifier a owl:Class,
+ns1:ContentIdentifier a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A canonical, unique, immutable identifier"@en ;
-    rdfs:subClassOf ns1:IntegrityMethod ;
+    rdfs:subClassOf ns2:IntegrityMethod ;
     sh:nodeKind sh:BlankNode ;
-    sh:property [ sh:datatype xsd:anyURI ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns5:contentIdentifierValue ],
-        [ sh:class ns5:ContentIdentifierType ;
+    sh:property [ sh:class ns1:ContentIdentifierType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Software/ContentIdentifierType/gitoid> <https://spdx.org/rdf/3.0.1/terms/Software/ContentIdentifierType/swhid> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns5:contentIdentifierType ] .
+            sh:path ns1:contentIdentifierType ],
+        [ sh:datatype xsd:anyURI ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:contentIdentifierValue ] .
 
-ns5:File a owl:Class,
+ns1:File a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Refers to any object that stores content on a computer."@en ;
-    rdfs:subClassOf ns5:SoftwareArtifact ;
+    rdfs:subClassOf ns1:SoftwareArtifact ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:contentType ;
-            sh:pattern "^[^\\/]+\\/[^\\/]+$" ],
-        [ sh:class ns5:FileKindType ;
+    sh:property [ sh:class ns1:FileKindType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/Software/FileKindType/file> <https://spdx.org/rdf/3.0.1/terms/Software/FileKindType/directory> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns5:fileKind ] .
+            sh:path ns1:fileKind ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:contentType ;
+            sh:pattern "^[^\\/]+\\/[^\\/]+$" ] .
 
-ns5:Package a owl:Class,
+ns1:Package a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Refers to any unit of content that can be associated with a distribution of
 software."""@en ;
-    rdfs:subClassOf ns5:SoftwareArtifact ;
+    rdfs:subClassOf ns1:SoftwareArtifact ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns5:homePage ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns5:sourceInfo ],
+            sh:path ns1:packageUrl ],
         [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns5:packageUrl ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns5:packageVersion ],
+            sh:path ns1:homePage ],
         [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns5:downloadLocation ] .
+            sh:path ns1:downloadLocation ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:packageVersion ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:sourceInfo ] .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/application> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "application" ;
-    rdfs:comment "the Element is a software application"@en .
+    rdfs:comment "The Element is a software application."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/archive> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "archive" ;
-    rdfs:comment "the Element is an archived collection of one or more files (.tar, .zip, etc)"@en .
+    rdfs:comment "The Element is an archived collection of one or more files (.tar, .zip, etc.)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/bom> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "bom" ;
-    rdfs:comment "Element is a bill of materials"@en .
+    rdfs:comment "The Element is a bill of materials."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/configuration> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "configuration" ;
-    rdfs:comment "Element is configuration data"@en .
+    rdfs:comment "The Element is configuration data."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/container> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "container" ;
-    rdfs:comment "the Element is a container image which can be used by a container runtime application"@en .
+    rdfs:comment "The Element is a container image which can be used by a container runtime application."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/data> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "data" ;
-    rdfs:comment "Element is data"@en .
+    rdfs:comment "The Element is data."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/device> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "device" ;
-    rdfs:comment "the Element refers to a chipset, processor, or electronic board"@en .
+    rdfs:comment "The Element refers to a chipset, processor, or electronic board."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/deviceDriver> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "deviceDriver" ;
-    rdfs:comment "Element represents software that controls hardware devices"@en .
+    rdfs:comment "The Element represents software that controls hardware devices."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/diskImage> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "diskImage" ;
-    rdfs:comment "the Element refers to a disk image that can be written to a disk, booted in a VM, etc. A disk image typically contains most or all of the components necessary to boot, such as bootloaders, kernels, firmware, userspace, etc."@en .
+    rdfs:comment "The Element refers to a disk image that can be written to a disk, booted in a VM, etc. A disk image typically contains most or all of the components necessary to boot, such as bootloaders, kernels, firmware, userspace, etc."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/documentation> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "documentation" ;
-    rdfs:comment "Element is documentation"@en .
+    rdfs:comment "The Element is documentation."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/evidence> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "evidence" ;
-    rdfs:comment "the Element is the evidence that a specification or requirement has been fulfilled"@en .
+    rdfs:comment "The Element is the evidence that a specification or requirement has been fulfilled."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/executable> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "executable" ;
-    rdfs:comment "Element is an Artifact that can be run on a computer"@en .
+    rdfs:comment "The Element is an Artifact that can be run on a computer."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/file> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "file" ;
-    rdfs:comment "the Element is a single file which can be independently distributed (configuration file, statically linked binary, Kubernetes deployment, etc)"@en .
+    rdfs:comment "The Element is a single file which can be independently distributed (configuration file, statically linked binary, Kubernetes deployment, etc.)."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/filesystemImage> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "filesystemImage" ;
-    rdfs:comment "the Element is a file system image that can be written to a disk (or virtual) partition"@en .
+    rdfs:comment "The Element is a file system image that can be written to a disk (or virtual) partition."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/firmware> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "firmware" ;
-    rdfs:comment "the Element provides low level control over a device's hardware"@en .
+    rdfs:comment "The Element provides low level control over a device's hardware."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/framework> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "framework" ;
-    rdfs:comment "the Element is a software framework"@en .
+    rdfs:comment "The Element is a software framework."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/install> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "install" ;
-    rdfs:comment "the Element is used to install software on disk"@en .
+    rdfs:comment "The Element is used to install software on disk."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/library> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "library" ;
-    rdfs:comment "the Element is a software library"@en .
+    rdfs:comment "The Element is a software library."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/manifest> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "manifest" ;
-    rdfs:comment "the Element is a software manifest"@en .
+    rdfs:comment "The Element is a software manifest."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/model> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "model" ;
-    rdfs:comment "the Element is a machine learning or artificial intelligence model"@en .
+    rdfs:comment "The Element is a machine learning or artificial intelligence model."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/module> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "module" ;
-    rdfs:comment "the Element is a module of a piece of software"@en .
+    rdfs:comment "The Element is a module of a piece of software."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/operatingSystem> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "operatingSystem" ;
-    rdfs:comment "the Element is an operating system"@en .
+    rdfs:comment "The Element is an operating system."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/other> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "other" ;
-    rdfs:comment "the Element doesn't fit into any of the other categories"@en .
+    rdfs:comment "The Element doesn't fit into any of the other categories."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/patch> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "patch" ;
-    rdfs:comment "Element contains a set of changes to update, fix, or improve another Element"@en .
+    rdfs:comment "The Element contains a set of changes to update, fix, or improve another Element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/platform> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "platform" ;
-    rdfs:comment "Element represents a runtime environment"@en .
+    rdfs:comment "The Element represents a runtime environment."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/requirement> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "requirement" ;
-    rdfs:comment "the Element provides a requirement needed as input for another Element"@en .
+    rdfs:comment "The Element provides a requirement needed as input for another Element."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/source> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "source" ;
-    rdfs:comment "the Element is a single or a collection of source files"@en .
+    rdfs:comment "The Element is a single or a collection of source files."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/specification> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "specification" ;
-    rdfs:comment "the Element is a plan, guideline or strategy how to create, perform or analyse an application"@en .
+    rdfs:comment "The Element is a plan, guideline or strategy how to create, perform or analyze an application."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/test> a owl:NamedIndividual,
-        ns5:SoftwarePurpose ;
+        ns1:SoftwarePurpose ;
     rdfs:label "test" ;
-    rdfs:comment "The Element is a test used to verify functionality on an software element"@en .
+    rdfs:comment "The Element is a test used to verify functionality on an software element."@en .
+
+ns2:ElementCollection a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "A collection of Elements, not necessarily with unifying context."@en ;
+    rdfs:subClassOf ns2:Element ;
+    sh:nodeKind sh:IRI ;
+    sh:not [ sh:class ns2:ElementCollection ;
+            sh:message "https://spdx.org/rdf/3.0.1/terms/Core/ElementCollection is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ] ;
+    sh:property [ sh:class ns2:Element ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns2:rootElement ],
+        [ sh:class ns2:Element ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns2:element ],
+        [ sh:class ns2:ProfileIdentifierType ;
+            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/core> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/software> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/simpleLicensing> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/expandedLicensing> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/security> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/build> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/ai> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/dataset> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/extension> <https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/lite> ) ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns2:profileConformance ] .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/no> a owl:NamedIndividual,
-        ns1:PresenceType ;
+        ns2:PresenceType ;
     rdfs:label "no" ;
     rdfs:comment "Indicates absence of the field."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/noAssertion> a owl:NamedIndividual,
-        ns1:PresenceType ;
+        ns2:PresenceType ;
     rdfs:label "noAssertion" ;
     rdfs:comment "Makes no assertion about the field."@en .
 
 <https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/yes> a owl:NamedIndividual,
-        ns1:PresenceType ;
+        ns2:PresenceType ;
     rdfs:label "yes" ;
     rdfs:comment "Indicates presence of the field."@en .
 
-ns1:contentType a owl:DatatypeProperty ;
+ns2:contentType a owl:DatatypeProperty ;
     rdfs:comment "Provides information about the content type of an Element or a Property."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.0.1/terms/Extension/Extension> a ns7:AbstractClass,
-        owl:Class ;
-    rdfs:comment "A characterization of some aspect of an Element that is associated with the Element in a generalized fashion."@en ;
-    sh:nodeKind sh:BlankNode .
-
-ns2:score a owl:DatatypeProperty ;
+ns3:score a owl:DatatypeProperty ;
     rdfs:comment "Provides a numerical (0-10) representation of the severity of a vulnerability."@en ;
     rdfs:range xsd:decimal .
 
-ns2:vectorString a owl:DatatypeProperty ;
+ns3:vectorString a owl:DatatypeProperty ;
     rdfs:comment "Specifies the CVSS vector string for a vulnerability."@en ;
     rdfs:range xsd:string .
 
-ns5:SoftwareArtifact a ns7:AbstractClass,
-        owl:Class,
-        sh:NodeShape ;
-    rdfs:comment "A distinct article or unit related to Software."@en ;
-    rdfs:subClassOf ns1:Artifact ;
-    sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns5:attributionText ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns5:copyrightText ],
-        [ sh:class ns5:SoftwarePurpose ;
-            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/application> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/archive> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/bom> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/configuration> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/container> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/data> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/device> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/diskImage> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/deviceDriver> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/documentation> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/evidence> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/executable> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/file> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/filesystemImage> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/firmware> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/framework> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/install> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/library> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/manifest> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/model> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/module> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/operatingSystem> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/other> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/patch> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/platform> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/requirement> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/source> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/specification> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/test> ) ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns5:primaryPurpose ],
-        [ sh:class ns5:ContentIdentifier ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns5:contentIdentifier ],
-        [ sh:class ns5:SoftwarePurpose ;
-            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/application> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/archive> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/bom> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/configuration> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/container> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/data> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/device> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/diskImage> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/deviceDriver> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/documentation> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/evidence> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/executable> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/file> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/filesystemImage> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/firmware> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/framework> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/install> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/library> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/manifest> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/model> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/module> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/operatingSystem> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/other> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/patch> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/platform> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/requirement> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/source> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/specification> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/test> ) ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns5:additionalPurpose ] .
-
-ns1:AnnotationType a owl:Class ;
+ns2:AnnotationType a owl:Class ;
     rdfs:comment "Specifies the type of an annotation."@en .
 
-ns1:Artifact a ns7:AbstractClass,
-        owl:Class,
-        sh:NodeShape ;
-    rdfs:comment "A distinct article or unit within the digital domain."@en ;
-    rdfs:subClassOf ns1:Element ;
-    sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:builtTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:validUntilTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:standardName ],
-        [ sh:class ns1:Agent ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:suppliedBy ],
-        [ sh:class ns1:SupportType ;
-            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/development> <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/support> <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/deployed> <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/limitedSupport> <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/endOfSupport> <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/noSupport> <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/noAssertion> ) ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:supportLevel ],
-        [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:releaseTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:class ns1:Agent ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:originatedBy ] .
-
-ns1:PositiveIntegerRange a owl:Class,
+ns2:PositiveIntegerRange a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A tuple of two positive integers that define a range."@en ;
     sh:nodeKind sh:BlankNode ;
@@ -2962,307 +2902,377 @@ ns1:PositiveIntegerRange a owl:Class,
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:beginIntegerRange ],
+            sh:path ns2:beginIntegerRange ],
         [ sh:datatype xsd:positiveInteger ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:endIntegerRange ] .
+            sh:path ns2:endIntegerRange ] .
 
-ns3:ExtendableLicense a ns7:AbstractClass,
-        owl:Class ;
+<https://spdx.org/rdf/3.0.1/terms/Extension/Extension> a owl:Class ;
+    rdfs:comment "A characterization of some aspect of an Element that is associated with the Element in a generalized fashion."@en ;
+    sh:nodeKind sh:BlankNode ;
+    sh:not [ sh:class <https://spdx.org/rdf/3.0.1/terms/Extension/Extension> ;
+            sh:message "https://spdx.org/rdf/3.0.1/terms/Extension/Extension is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ] .
+
+ns3:ExploitCatalogType a owl:Class ;
+    rdfs:comment "Specifies the exploit catalog type."@en .
+
+ns1:ContentIdentifierType a owl:Class ;
+    rdfs:comment "Specifies the type of a content identifier."@en .
+
+ns1:FileKindType a owl:Class ;
+    rdfs:comment "Enumeration of the different kinds of SPDX file."@en .
+
+ns1:SoftwareArtifact a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "A distinct article or unit related to Software."@en ;
+    rdfs:subClassOf ns2:Artifact ;
+    sh:nodeKind sh:IRI ;
+    sh:not [ sh:class ns1:SoftwareArtifact ;
+            sh:message "https://spdx.org/rdf/3.0.1/terms/Software/SoftwareArtifact is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ] ;
+    sh:property [ sh:class ns1:ContentIdentifier ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns1:contentIdentifier ],
+        [ sh:class ns1:SoftwarePurpose ;
+            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/application> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/archive> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/bom> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/configuration> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/container> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/data> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/device> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/diskImage> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/deviceDriver> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/documentation> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/evidence> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/executable> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/file> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/filesystemImage> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/firmware> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/framework> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/install> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/library> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/manifest> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/model> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/module> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/operatingSystem> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/other> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/patch> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/platform> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/requirement> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/source> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/specification> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/test> ) ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:primaryPurpose ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:attributionText ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:copyrightText ],
+        [ sh:class ns1:SoftwarePurpose ;
+            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/application> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/archive> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/bom> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/configuration> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/container> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/data> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/device> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/diskImage> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/deviceDriver> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/documentation> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/evidence> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/executable> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/file> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/filesystemImage> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/firmware> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/framework> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/install> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/library> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/manifest> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/model> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/module> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/operatingSystem> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/other> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/patch> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/platform> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/requirement> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/source> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/specification> <https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/test> ) ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:additionalPurpose ] .
+
+ns5:EnergyUnitType a owl:Class ;
+    rdfs:comment "Specifies the unit of energy consumption."@en .
+
+ns2:Artifact a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "A distinct article or unit within the digital domain."@en ;
+    rdfs:subClassOf ns2:Element ;
+    sh:nodeKind sh:IRI ;
+    sh:not [ sh:class ns2:Artifact ;
+            sh:message "https://spdx.org/rdf/3.0.1/terms/Core/Artifact is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ] ;
+    sh:property [ sh:class ns2:Agent ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns2:suppliedBy ],
+        [ sh:class ns2:Agent ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns2:originatedBy ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:releaseTime ;
+            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:builtTime ;
+            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:validUntilTime ;
+            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:standardName ],
+        [ sh:class ns2:SupportType ;
+            sh:in ( <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/development> <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/support> <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/deployed> <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/limitedSupport> <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/endOfSupport> <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/noSupport> <https://spdx.org/rdf/3.0.1/terms/Core/SupportType/noAssertion> ) ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns2:supportLevel ] .
+
+ns2:RelationshipCompleteness a owl:Class ;
+    rdfs:comment "Indicates whether a relationship is known to be complete, incomplete, or if no assertion is made with respect to relationship completeness."@en .
+
+ns2:comment a owl:DatatypeProperty ;
+    rdfs:comment """Provide consumers with comments by the creator of the Element about the
+Element."""@en ;
+    rdfs:range xsd:string .
+
+ns6:ExtendableLicense a owl:Class ;
     rdfs:comment "Abstract class representing a License or an OrLaterOperator."@en ;
     rdfs:subClassOf <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> ;
-    sh:nodeKind sh:IRI .
+    sh:nodeKind sh:IRI ;
+    sh:not [ sh:class ns6:ExtendableLicense ;
+            sh:message "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/ExtendableLicense is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ] .
 
-ns3:IndividualLicensingInfo a owl:Class ;
-    rdfs:comment """A concrete subclass of AnyLicenseInfo used by Individuals in the
-ExpandedLicensing profile."""@en ;
-    rdfs:subClassOf <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> ;
-    sh:nodeKind sh:IRI .
-
-ns3:License a ns7:AbstractClass,
-        owl:Class,
+ns6:License a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Abstract class for the portion of an AnyLicenseInfo representing a license."@en ;
-    rdfs:subClassOf ns3:ExtendableLicense ;
+    rdfs:subClassOf ns6:ExtendableLicense ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
+    sh:not [ sh:class ns6:License ;
+            sh:message "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/License is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ] ;
+    sh:property [ sh:datatype xsd:anyURI ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:standardLicenseHeader ],
-        [ sh:datatype xsd:boolean ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns3:isDeprecatedLicenseId ],
+            sh:path ns6:seeAlso ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:standardLicenseTemplate ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns3:obsoletedBy ],
-        [ sh:datatype xsd:boolean ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns3:isFsfLibre ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns3:licenseXml ],
+            sh:path ns6:obsoletedBy ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/licenseText> ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns6:standardLicenseHeader ],
         [ sh:datatype xsd:boolean ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:isOsiApproved ],
-        [ sh:datatype xsd:anyURI ;
+            sh:path ns6:isDeprecatedLicenseId ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:seeAlso ] .
+            sh:path ns6:standardLicenseTemplate ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns6:licenseXml ],
+        [ sh:datatype xsd:boolean ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns6:isFsfLibre ],
+        [ sh:datatype xsd:boolean ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns6:isOsiApproved ] .
 
-ns3:LicenseAddition a ns7:AbstractClass,
-        owl:Class,
+ns6:LicenseAddition a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Abstract class for additional text intended to be added to a License, but
 which is not itself a standalone License."""@en ;
-    rdfs:subClassOf ns1:Element ;
+    rdfs:subClassOf ns2:Element ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
+    sh:not [ sh:class ns6:LicenseAddition ;
+            sh:message "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/LicenseAddition is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ] ;
+    sh:property [ sh:datatype xsd:anyURI ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:standardAdditionTemplate ],
-        [ sh:datatype xsd:anyURI ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns3:seeAlso ],
+            sh:path ns6:seeAlso ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:obsoletedBy ],
+            sh:path ns6:licenseXml ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:licenseXml ],
+            sh:path ns6:obsoletedBy ],
         [ sh:datatype xsd:boolean ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:isDeprecatedAdditionId ],
+            sh:path ns6:isDeprecatedAdditionId ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:additionText ] .
-
-ns2:ExploitCatalogType a owl:Class ;
-    rdfs:comment "Specifies the exploit catalog type."@en .
-
-ns2:VexVulnAssessmentRelationship a ns7:AbstractClass,
-        owl:Class,
-        sh:NodeShape ;
-    rdfs:comment "Asbtract ancestor class for all VEX relationships"@en ;
-    rdfs:subClassOf ns2:VulnAssessmentRelationship ;
-    sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns2:statusNotes ],
+            sh:path ns6:additionText ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:vexVersion ] .
+            sh:path ns6:standardAdditionTemplate ] .
 
-ns5:ContentIdentifierType a owl:Class ;
-    rdfs:comment "Specifies the type of a content identifier."@en .
+ns3:VexVulnAssessmentRelationship a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "Abstract ancestor class for all VEX relationships"@en ;
+    rdfs:subClassOf ns3:VulnAssessmentRelationship ;
+    sh:nodeKind sh:IRI ;
+    sh:not [ sh:class ns3:VexVulnAssessmentRelationship ;
+            sh:message "https://spdx.org/rdf/3.0.1/terms/Security/VexVulnAssessmentRelationship is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ] ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns3:vexVersion ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns3:statusNotes ] .
 
-ns5:FileKindType a owl:Class ;
-    rdfs:comment "Enumeration of the different kinds of SPDX file."@en .
-
-ns6:EnergyUnitType a owl:Class ;
-    rdfs:comment "Specifies the unit of energy consumption."@en .
-
-ns1:RelationshipCompleteness a owl:Class ;
-    rdfs:comment "Indicates whether a relationship is known to be complete, incomplete, or if no assertion is made with respect to relationship completeness."@en .
-
-ns1:comment a owl:DatatypeProperty ;
-    rdfs:comment """Provide consumers with comments by the creator of the Element about the
-Element."""@en ;
-    rdfs:range xsd:string .
-
-ns6:EnergyConsumptionDescription a owl:Class,
+ns5:EnergyConsumptionDescription a owl:Class,
         sh:NodeShape ;
     rdfs:comment """The class that helps note down the quantity of energy consumption and the unit
 used for measurement."""@en ;
     sh:nodeKind sh:BlankNode ;
-    sh:property [ sh:class ns6:EnergyUnitType ;
+    sh:property [ sh:class ns5:EnergyUnitType ;
             sh:in ( <https://spdx.org/rdf/3.0.1/terms/AI/EnergyUnitType/kilowattHour> <https://spdx.org/rdf/3.0.1/terms/AI/EnergyUnitType/megajoule> <https://spdx.org/rdf/3.0.1/terms/AI/EnergyUnitType/other> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns6:energyUnit ],
+            sh:path ns5:energyUnit ],
         [ sh:datatype xsd:decimal ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns6:energyQuantity ] .
+            sh:path ns5:energyQuantity ] .
 
-ns6:SafetyRiskAssessmentType a owl:Class ;
+ns5:SafetyRiskAssessmentType a owl:Class ;
     rdfs:comment "Specifies the safety risk level."@en .
-
-ns1:IntegrityMethod a ns7:AbstractClass,
-        owl:Class,
-        sh:NodeShape ;
-    rdfs:comment "Provides an independently reproducible mechanism that permits verification of a specific Element."@en ;
-    sh:nodeKind sh:BlankNode ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:comment ] .
 
 ns4:ConfidentialityLevelType a owl:Class ;
     rdfs:comment "Categories of confidentiality level."@en .
 
-ns2:SsvcDecisionType a owl:Class ;
+ns3:SsvcDecisionType a owl:Class ;
     rdfs:comment "Specifies the SSVC decision type."@en .
+
+ns2:IntegrityMethod a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "Provides an independently reproducible mechanism that permits verification of a specific Element."@en ;
+    sh:nodeKind sh:BlankNode ;
+    sh:not [ sh:class ns2:IntegrityMethod ;
+            sh:message "https://spdx.org/rdf/3.0.1/terms/Core/IntegrityMethod is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ] ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:comment ] .
 
 ns4:DatasetAvailabilityType a owl:Class ;
     rdfs:comment "Availability of dataset."@en .
 
-ns2:VexJustificationType a owl:Class ;
+ns3:VexJustificationType a owl:Class ;
     rdfs:comment "Specifies the VEX justification type."@en .
 
-ns2:VulnAssessmentRelationship a ns7:AbstractClass,
-        owl:Class,
-        sh:NodeShape ;
-    rdfs:comment "Abstract ancestor class for all vulnerability assessments"@en ;
-    rdfs:subClassOf ns1:Relationship ;
-    sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:Agent ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:suppliedBy ],
-        [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns2:withdrawnTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns2:publishedTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:class ns1:Element ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns2:assessedElement ],
-        [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns2:modifiedTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ] .
-
-ns1:LifecycleScopeType a owl:Class ;
+ns2:LifecycleScopeType a owl:Class ;
     rdfs:comment "Provide an enumerated set of lifecycle phases that can provide context to relationships."@en .
 
-ns2:CvssSeverityType a owl:Class ;
+ns3:CvssSeverityType a owl:Class ;
     rdfs:comment "Specifies the CVSS base, temporal, threat, or environmental severity type."@en .
 
-ns5:SbomType a owl:Class ;
+ns3:VulnAssessmentRelationship a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "Abstract ancestor class for all vulnerability assessments"@en ;
+    rdfs:subClassOf ns2:Relationship ;
+    sh:nodeKind sh:IRI ;
+    sh:not [ sh:class ns3:VulnAssessmentRelationship ;
+            sh:message "https://spdx.org/rdf/3.0.1/terms/Security/VulnAssessmentRelationship is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ] ;
+    sh:property [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns3:modifiedTime ;
+            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+        [ sh:class ns2:Element ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns3:assessedElement ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns3:publishedTime ;
+            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+        [ sh:class ns2:Agent ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns2:suppliedBy ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns3:withdrawnTime ;
+            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ] .
+
+ns1:SbomType a owl:Class ;
     rdfs:comment """Provides a set of values to be used to describe the common types of SBOMs that
 tools may create."""@en .
 
-ns1:PresenceType a owl:Class ;
+ns2:PresenceType a owl:Class ;
     rdfs:comment "Categories of presence or absence."@en .
 
-ns1:SupportType a owl:Class ;
+ns2:SupportType a owl:Class ;
     rdfs:comment "Indicates the type of support that is associated with an artifact."@en .
 
-ns1:Agent a owl:Class ;
+ns2:Agent a owl:Class ;
     rdfs:comment "Agent represents anything with the potential to act on a system."@en ;
-    rdfs:subClassOf ns1:Element ;
+    rdfs:subClassOf ns2:Element ;
     sh:nodeKind sh:IRI .
 
-<https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> a ns7:AbstractClass,
-        owl:Class ;
-    rdfs:comment "Abstract class representing a license combination consisting of one or more licenses."@en ;
-    rdfs:subClassOf ns1:Element ;
-    sh:nodeKind sh:IRI .
-
-ns7:AbstractClass a owl:Class .
-
-ns1:ProfileIdentifierType a owl:Class ;
+ns2:ProfileIdentifierType a owl:Class ;
     rdfs:comment "Enumeration of the valid profiles."@en .
 
-ns1:ExternalIdentifierType a owl:Class ;
+<https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> a owl:Class ;
+    rdfs:comment "Abstract class representing a license combination consisting of one or more licenses."@en ;
+    rdfs:subClassOf ns2:Element ;
+    sh:nodeKind sh:IRI ;
+    sh:not [ sh:class <https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo> ;
+            sh:message "https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ] .
+
+ns2:ExternalIdentifierType a owl:Class ;
     rdfs:comment "Specifies the type of an external identifier."@en .
 
-ns1:DictionaryEntry a owl:Class,
+ns2:DictionaryEntry a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A key with an associated value."@en ;
     sh:nodeKind sh:BlankNode ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
-            sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:key ],
+            sh:path ns2:value ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
+            sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:value ] .
+            sh:path ns2:key ] .
 
 ns4:DatasetType a owl:Class ;
     rdfs:comment "Enumeration of dataset types."@en .
 
-ns1:HashAlgorithm a owl:Class ;
-    rdfs:comment "A mathematical algorithm that maps data of arbitrary size to a bit string."@en .
-
-ns1:Element a ns7:AbstractClass,
-        owl:Class,
+ns2:Element a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Base domain class from which all other SPDX-3.0 domain classes derive."@en ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:ExternalRef ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:externalRef ],
-        [ sh:class ns1:ExternalIdentifier ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:externalIdentifier ],
-        [ sh:datatype xsd:string ;
+    sh:not [ sh:class ns2:Element ;
+            sh:message "https://spdx.org/rdf/3.0.1/terms/Core/Element is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ] ;
+    sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:name ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:description ],
-        [ sh:class ns1:IntegrityMethod ;
+            sh:path ns2:description ],
+        [ sh:class ns2:ExternalIdentifier ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:verifiedUsing ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:comment ],
-        [ sh:class ns1:CreationInfo ;
+            sh:path ns2:externalIdentifier ],
+        [ sh:class ns2:CreationInfo ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:creationInfo ],
-        [ sh:class <https://spdx.org/rdf/3.0.1/terms/Extension/Extension> ;
+            sh:path ns2:creationInfo ],
+        [ sh:class ns2:IntegrityMethod ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:extension ],
+            sh:path ns2:verifiedUsing ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:summary ] .
+            sh:path ns2:summary ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:comment ],
+        [ sh:class <https://spdx.org/rdf/3.0.1/terms/Extension/Extension> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns2:extension ],
+        [ sh:class ns2:ExternalRef ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns2:externalRef ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:name ] .
 
-ns5:SoftwarePurpose a owl:Class ;
+ns2:HashAlgorithm a owl:Class ;
+    rdfs:comment "A mathematical algorithm that maps data of arbitrary size to a bit string."@en .
+
+ns1:SoftwarePurpose a owl:Class ;
     rdfs:comment "Provides information about the primary purpose of an Element."@en .
 
-ns1:ExternalRefType a owl:Class ;
+ns2:ExternalRefType a owl:Class ;
     rdfs:comment "Specifies the type of an external reference."@en .
 
-ns1:RelationshipType a owl:Class ;
+ns2:RelationshipType a owl:Class ;
     rdfs:comment "Information about the relationship between two Elements."@en .
 


### PR DESCRIPTION
There are two changes in the latest SHACL file generated from spec-parser:
- Abstract classes now use a shape constraint rather than an artificial superclass
- Individuals no longer have a range to denote the classes they belong to