### PR TITLE
Fix typo StringBuilder.setLenght -> setLength

### DIFF
--- a/resources/javaTemplates/ToStringWithPropertiesTemplate.txt
+++ b/resources/javaTemplates/ToStringWithPropertiesTemplate.txt
@@ -20,8 +20,8 @@
 			{{/nonOptional}}
 			sb.append(" ");
 			{{/toStringProperties}}
-			sb.setLenght(sb.length() == 0 ? 0 : sb.length()-1);
+			sb.setLength(sb.length() == 0 ? 0 : sb.length()-1);
 			return sb.toString();
 		} catch (InvalidSPDXAnalysisException e) {
-			return "Error: "+e.getMessage();
+			return "Error: " + e.getMessage();
 		}


### PR DESCRIPTION
Fix typo in the Java template
