### PR TITLE
Add a module name in the manifest file

### DIFF
--- a/resources/javaTemplates/PomTemplate.txt
+++ b/resources/javaTemplates/PomTemplate.txt
@@ -184,6 +184,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.3.0</version>
+        <configuration>
+          <archive>
+              <manifestEntries>
+                  <Automatic-Module-Name>org.spdx.model.v3</Automatic-Module-Name>
+              </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR adds a the Automatic-Module-Name manifest entry, making it easier for modular projects (Java 9 and above) to include this library.