### PR TITLE
Generate API doc website

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 SPDX contributors
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+name: Generate and publish API JavaDocs
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 21
+    - name: Cache Maven packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+
+    - name: Generate docs
+      run: mvn javadoc:javadoc
+
+    - name: Deploy docs
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./target/reports/apidocs

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ To run the utility as a command line interface, execute the main method `ShaclTo
 
 To use the code as a library, the main entry point is the `ShaclToJava` class which takes a single parameter of the SPDX Ontology model.
 
-The `generate(dir)` method will generate the Java files in the dir directory.
+The `generate(dir)` method will generate the Java files in the `dir` directory.
+
+The API documentation is available at: <https://spdx.github.io/spdx-model-to-java>
 
 ## Development Status
 


### PR DESCRIPTION
Add workflow to generate Java doc website

Note that the GitHub Pages has to be enabled for the generated website to be deployed.

The doc will be available at
https://spdx.github.io/spdx-model-to-java/