### PR TITLE
Fix API doc output directory

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,4 +33,4 @@ jobs:
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./target/reports/apidocs
+        publish_dir: ./target/site/apidocs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,4 +33,4 @@ jobs:
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./target/site/apidocs
+        publish_dir: ./target/reports/apidocs

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
+				<version>2.9</version>
 				<configuration>
 					<quiet>true</quiet>
 					<source>8</source>

--- a/pom.xml
+++ b/pom.xml
@@ -191,11 +191,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<configuration>
 					<quiet>true</quiet>
 					<source>8</source>
 					<javadocExecutable>${env.JAVA_HOME}/bin/javadoc</javadocExecutable>
+					<reportOutputDirectory>${project.build.directory}/reports/apidocs</reportOutputDirectory>
 					<additionalparam>-Xdoclint:none</additionalparam>
 				</configuration>
 				<executions>


### PR DESCRIPTION
I've tried to generate the API doc locally and found that for this project, the `mvn javadoc:javadoc` command gives the output to `./target/site/apidocs` directory instead of `./target/reports/apidocs` like in other projects.

This made the actions-gh-pages unable to find the publish_dir
- See "no such file or directory" error message in the workflow run at https://github.com/spdx/spdx-model-to-java/actions/runs/14686776425/job/41216685955#step:6:64
- Because of this, nothing got deployed, as reported in https://github.com/spdx/spdx-model-to-java/pull/18#issuecomment-2832853523 

To fix this, set `reportOutputDirectory` in maven-javadoc-plugin to explicitly specify the output dir to `./target/reports/apidocs`.


