### PR TITLE
Update to latest SPDX model 3.1 schema

### DIFF
--- a/resources/javaTemplates/ModelInfoTemplate.txt
+++ b/resources/javaTemplates/ModelInfoTemplate.txt
@@ -24,7 +24,7 @@ import org.spdx.storage.IModelStore;
  * GENERATED
  *
  */
-public class SpdxModelInfoV3_0 implements ISpdxModelInfo {
+public class SpdxModelInfo{{{versionSuffix}}} implements ISpdxModelInfo {
 
 	@Override
 	public Map<String, Enum<?>> getUriToEnumMap() {
@@ -33,7 +33,7 @@ public class SpdxModelInfoV3_0 implements ISpdxModelInfo {
 
 	@Override
 	public List<String> getSpecVersions() {
-		return Arrays.asList(new String[] {"{{{versionSuffix}}}"});
+		return Arrays.asList(new String[] {"{{{versionSemVer}}}"});
 	}
 
 	@Override

--- a/src/main/java/org/spdx/tools/model2java/ShaclToJava.java
+++ b/src/main/java/org/spdx/tools/model2java/ShaclToJava.java
@@ -39,6 +39,7 @@ import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
@@ -88,6 +89,7 @@ public class ShaclToJava {
 	List<ObjectProperty> allObjectProperties;
 	List<Resource> objectIndividuals;
 	String versionSemVer;
+	String spdxNamespace;
 	String versionSuffix;
 	
 	public enum PropertyType {
@@ -126,15 +128,15 @@ public class ShaclToJava {
 	/**
 	 * @param model model to use to generate the java files
 	 * @param packageVersion version string to use in package names
+	 * @param specVersion SEMVER version of the spec
 	 */
-	public ShaclToJava(OntModel model, String packageVersion) {
+	public ShaclToJava(OntModel model, String packageVersion, String specVersion) {
 		this.model = model;
-		String spdxUri = model.getNsPrefixURI("spdx");
-		versionSemVer = spdxUri.substring("https://spdx.org/rdf/".length());
-		versionSemVer = versionSemVer.substring(0, versionSemVer.indexOf('/'));
-		versionSuffix = packageVersion;
 		shapes = Shapes.parse(model);
 		shapeMap = shapes.getShapeMap();
+		spdxNamespace = model.getNsPrefixURI("spdx");
+		versionSemVer = specVersion;
+		versionSuffix = packageVersion;
 		allIndividuals = model.listIndividuals().toList();
 		allClasses = model.listClasses().toList();
 		allDataProperties = model.listDatatypeProperties().toList();
@@ -519,7 +521,7 @@ public class ShaclToJava {
 		Path path = dir.toPath().resolve("src").resolve("main").resolve("java").resolve("org")
 				.resolve("spdx").resolve("library").resolve("model").resolve(versionSuffix);
 		Files.createDirectories(path);
-		File file = path.resolve("SpdxModelInfoV3_0.java").toFile();
+		File file = path.resolve(String.format("SpdxModelInfo%s.java", versionSuffix)).toFile();
 		file.createNewFile();
 		Map<String, Object> mustacheMap = new HashMap<>();
 		mustacheMap.put("versionSuffix", versionSuffix);
@@ -1208,7 +1210,7 @@ public class ShaclToJava {
 		requiredImports.add("import org.spdx.library.model."+versionSuffix+".core.Agent.AgentBuilder;");
 		requiredImports.add("import java.util.Arrays;");
 		requiredImports.add("import org.spdx.core.ModelRegistry;");
-		requiredImports.add("import org.spdx.library.model."+versionSuffix+".SpdxModelInfoV3_0;");
+		requiredImports.add("import org.spdx.library.model."+versionSuffix+".SpdxModelInfo"+versionSuffix+";");
 		requiredImports.add("import org.spdx.library.model."+versionSuffix+".TestValuesGenerator;");
 		imports = buildImports(new ArrayList<String>(requiredImports));
 		unitTestMap.put("imports", imports.toArray(new String[imports.size()]));
@@ -1267,17 +1269,17 @@ public class ShaclToJava {
 		if (classUri.endsWith("ExpandedLicensing/WithAdditionOperator")) {
 			Map<String, Object> mustacheMap = new HashMap<>();
 			mustacheMap.put("className", uriToClassName.get(classUri));
-			String subjectAdditionPropertyName = uriToPropertyName.get("https://spdx.org/rdf/"+versionSemVer+"/terms/ExpandedLicensing/subjectAddition");
+			String subjectAdditionPropertyName = uriToPropertyName.get(spdxNamespace + "ExpandedLicensing/subjectAddition");
 			String subjectLicenseGetter = "get" + subjectAdditionPropertyName.substring(0, 1).toUpperCase() + subjectAdditionPropertyName.substring(1);
 			mustacheMap.put("subjectAdditionGetter", subjectLicenseGetter);
-			String subjectExtendablePropertyName = uriToPropertyName.get("https://spdx.org/rdf/"+versionSemVer+"/terms/ExpandedLicensing/subjectExtendableLicense");
+			String subjectExtendablePropertyName = uriToPropertyName.get(spdxNamespace + "ExpandedLicensing/subjectExtendableLicense");
 			String extendableLicenseGetter = "get" + subjectExtendablePropertyName.substring(0, 1).toUpperCase() + subjectExtendablePropertyName.substring(1);
 			mustacheMap.put("extendableLicenseGetter", extendableLicenseGetter);
 			return mustacheToString(ShaclToJavaConstants.WITH_OPERATOR_TO_STRING_TEMPLATE, mustacheMap);
 		} else if (classUri.endsWith("ExpandedLicensing/OrLaterOperator")) {
 			Map<String, Object> mustacheMap = new HashMap<>();
 			mustacheMap.put("className", uriToClassName.get(classUri));
-			String subjectPropertyName = uriToPropertyName.get("https://spdx.org/rdf/"+versionSemVer+"/terms/ExpandedLicensing/subjectLicense");
+			String subjectPropertyName = uriToPropertyName.get(spdxNamespace + "ExpandedLicensing/subjectLicense");
 			String subjectLicenseGetter = "get" + subjectPropertyName.substring(0, 1).toUpperCase() + subjectPropertyName.substring(1);
 			mustacheMap.put("subjectLicenseGetter", subjectLicenseGetter);
 			return mustacheToString(ShaclToJavaConstants.OR_LATER_TO_STRING_TEMPLATE, mustacheMap);
@@ -1294,7 +1296,7 @@ public class ShaclToJava {
 		} else if (classUri.endsWith("ExpandedLicensing/ConjunctiveLicenseSet") ||
 				classUri.endsWith("ExpandedLicensing/DisjunctiveLicenseSet")) {
 			Map<String, Object> mustacheMap = new HashMap<>();
-			String licenseMemberPropName = uriToPropertyName.get("https://spdx.org/rdf/"+versionSemVer+"/terms/ExpandedLicensing/member") + "s";
+			String licenseMemberPropName = uriToPropertyName.get(spdxNamespace + "ExpandedLicensing/member") + "s";
 			String licenseMemberGetter = "get" + licenseMemberPropName.substring(0, 1).toUpperCase() + licenseMemberPropName.substring(1);
 			mustacheMap.put("licenseMembersGetter", licenseMemberGetter);
 			mustacheMap.put("operator", 
@@ -1302,7 +1304,7 @@ public class ShaclToJava {
 			return mustacheToString(ShaclToJavaConstants.LICENSE_SET_TO_STRING_TEMPLATE, mustacheMap);
 		}  else if (classUri.endsWith("Core/Element")) {
 			Map<String, Object> mustacheMap = new HashMap<>();
-			String nameProp = uriToPropertyName.get("https://spdx.org/rdf/"+versionSemVer+"/terms/Core/name");
+			String nameProp = uriToPropertyName.get(spdxNamespace + "Core/name");
 			String nameGetter = "get" + nameProp.substring(0, 1).toUpperCase() + nameProp.substring(1);
 			mustacheMap.put("nameGetter", nameGetter);
 			return mustacheToString(ShaclToJavaConstants.ELEMENT_TO_STRING_TEMPLATE, mustacheMap);
@@ -1337,7 +1339,7 @@ public class ShaclToJava {
 			mustacheMap.put("primeNumber", "1381");
 			requiredImports.add("import java.util.HashSet;");
 			requiredImports.add("import java.util.Iterator;");
-			String licenseMemberPropName = uriToPropertyName.get("https://spdx.org/rdf/"+versionSemVer+"/terms/ExpandedLicensing/member") + "s";
+			String licenseMemberPropName = uriToPropertyName.get(spdxNamespace + "ExpandedLicensing/member") + "s";
 			String licenseMemberGetter = "get" + licenseMemberPropName.substring(0, 1).toUpperCase() + licenseMemberPropName.substring(1);
 			mustacheMap.put("licenseMembersGetter", licenseMemberGetter);
 			return mustacheToString(ShaclToJavaConstants.LICENSE_SET_EQUALS_OVERRIDE_TEMPLATE, mustacheMap);
@@ -1348,7 +1350,7 @@ public class ShaclToJava {
 			mustacheMap.put("primeNumber", "41");
 			requiredImports.add("import java.util.HashSet;");
 			requiredImports.add("import java.util.Iterator;");
-			String licenseMemberPropName = uriToPropertyName.get("https://spdx.org/rdf/"+versionSemVer+"/terms/ExpandedLicensing/member") + "s";
+			String licenseMemberPropName = uriToPropertyName.get(spdxNamespace + "ExpandedLicensing/member") + "s";
 			String licenseMemberGetter = "get" + licenseMemberPropName.substring(0, 1).toUpperCase() + licenseMemberPropName.substring(1);
 			mustacheMap.put("licenseMembersGetter", licenseMemberGetter);
 			return mustacheToString(ShaclToJavaConstants.LICENSE_SET_EQUALS_OVERRIDE_TEMPLATE, mustacheMap);
@@ -1356,7 +1358,7 @@ public class ShaclToJava {
 		if (classUri.endsWith("ExpandedLicensing/OrLaterOperator")) {
 			Map<String, Object> mustacheMap = new HashMap<>();
 			mustacheMap.put("className", uriToClassName.get(classUri));
-			String subjectPropertyName = uriToPropertyName.get("https://spdx.org/rdf/"+versionSemVer+"/terms/ExpandedLicensing/subjectLicense");
+			String subjectPropertyName = uriToPropertyName.get(spdxNamespace + "ExpandedLicensing/subjectLicense");
 			String subjectLicenseGetter = "get" + subjectPropertyName.substring(0, 1).toUpperCase() + subjectPropertyName.substring(1);
 			mustacheMap.put("subjectLicenseGetter", subjectLicenseGetter);
 			return mustacheToString(ShaclToJavaConstants.OR_LATER_EQUALS_OVERRIDE_TEMPLATE, mustacheMap);
@@ -1364,10 +1366,10 @@ public class ShaclToJava {
 		if (classUri.endsWith("ExpandedLicensing/WithAdditionOperator")) {
 			Map<String, Object> mustacheMap = new HashMap<>();
 			mustacheMap.put("className", uriToClassName.get(classUri));
-			String subjectAdditionPropertyName = uriToPropertyName.get("https://spdx.org/rdf/"+versionSemVer+"/terms/ExpandedLicensing/subjectAddition");
+			String subjectAdditionPropertyName = uriToPropertyName.get(spdxNamespace + "ExpandedLicensing/subjectAddition");
 			String subjectLicenseGetter = "get" + subjectAdditionPropertyName.substring(0, 1).toUpperCase() + subjectAdditionPropertyName.substring(1);
 			mustacheMap.put("subjectAdditionGetter", subjectLicenseGetter);
-			String subjectExtendablePropertyName = uriToPropertyName.get("https://spdx.org/rdf/"+versionSemVer+"/terms/ExpandedLicensing/subjectExtendableLicense");
+			String subjectExtendablePropertyName = uriToPropertyName.get(spdxNamespace + "ExpandedLicensing/subjectExtendableLicense");
 			String extendableLicenseGetter = "get" + subjectExtendablePropertyName.substring(0, 1).toUpperCase() + subjectExtendablePropertyName.substring(1);
 			mustacheMap.put("extendableLicenseGetter", extendableLicenseGetter);
 			return mustacheToString(ShaclToJavaConstants.WITH_EQUALS_OVERRIDE_TEMPLATE, mustacheMap);
@@ -1573,7 +1575,7 @@ public class ShaclToJava {
 		if (ShaclToJavaConstants.SET_PROPERTY_SUFFIXES.contains(propertySuffix)) {
 			propertyType = PropertyType.OBJECT_SET;
 		} else if ("extension".equals(name)) {
-			propertyType = PropertyType.OBJECT; // workaround for https://github.com/spdx/spec-parser/issues/207
+			propertyType = PropertyType.OBJECT_COLLECTION; // workaround for https://github.com/spdx/spec-parser/issues/207
 		} else {
 			propertyType = determinePropertyType(classRestriction, dataTypeRestriction,
 					minCardinality, maxCardinality);
@@ -1586,7 +1588,7 @@ public class ShaclToJava {
 		}
  		retval.put("propertyType", propertyType);
 		String typeUri = "extension".equals(name) ?
-				String.format("https://spdx.org/rdf/%s/terms/Extension/Extension", this.versionSemVer) : // workaround for https://github.com/spdx/spec-parser/issues/207
+				spdxNamespace + "Extension/Extension" : // workaround for https://github.com/spdx/spec-parser/issues/207
 				getTypeUri(classRestriction, dataTypeRestriction);
 		String type;
 		if (ShaclToJavaConstants.BOOLEAN_TYPE.equals(typeUri)) {

--- a/src/main/java/org/spdx/tools/model2java/ShaclToJavaCli.java
+++ b/src/main/java/org/spdx/tools/model2java/ShaclToJavaCli.java
@@ -16,7 +16,12 @@ import java.util.Objects;
 
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
 
 /**
  * Command Line Interface for the ShaclToJava utility
@@ -101,17 +106,17 @@ public class ShaclToJavaCli {
 				String[] specVersionParts = specVersion.split("\\.");
 				String versionForPackageName = "v3_" +
 						(specVersionParts.length > 1 ? specVersionParts[1] : "0");
-				ShaclToJava s2j = new ShaclToJava(models.get(i), versionForPackageName);
+				ShaclToJava s2j = new ShaclToJava(models.get(i), versionForPackageName, specVersion);
 				warnings.addAll(s2j.generate(outputDir));
 				if ("3.0.1".equals(specVersion)) {
 					// generate the package version for the 3.0.1 patch version only - for compatibility
 					// going forward, we will only generate minor versions
-					ShaclToJava s2jdot = new ShaclToJava(models.get(i), "v3_0_1");
+					ShaclToJava s2jdot = new ShaclToJava(models.get(i), "v3_0_1", specVersion);
 					warnings.addAll(s2jdot.generate(outputDir));
 				}
 				if (i == models.size()-1) {
 					// for the latest version, create a package for the latest version
-					ShaclToJava s2jlatest = new ShaclToJava(models.get(i), "v3");
+					ShaclToJava s2jlatest = new ShaclToJava(models.get(i), "v3", specVersion);
 					warnings.addAll(s2jlatest.generate(outputDir));
 				}
 			} catch (IOException e) {
@@ -138,7 +143,26 @@ public class ShaclToJavaCli {
 	}
 
 	private static String getSpecVersion(OntModel model) {
-		String spdxUri = model.getNsPrefixURI("spdx");
+		//TODO: The following is a hack to work around https://github.com/spdx/spec-parser/issues/214
+		// Individual spdxOrg = model.getIndividual(model.getNsPrefixURI("ns1") + "SpdxOrganization");
+		String spdxUri = null;
+		try (QueryExecution query = QueryExecutionFactory.create(
+				"SELECT ?agent WHERE {<" + model.getNsPrefixURI("ns1") + "SpdxOrganization> <"
+						+ model.getNsPrefixURI("ns1") + "creationInfo> ?agent}", model)) {
+			ResultSet result = query.execSelect();
+			if (result.hasNext()) {
+				QuerySolution solution = result.next();
+				RDFNode agentNode = solution.get("?agent");
+				if (Objects.nonNull(agentNode)) {
+					spdxUri = agentNode.toString();
+				}
+			}
+
+		}
+		if (Objects.isNull(spdxUri)) {
+			spdxUri = model.getNsPrefixURI("spdx");
+		}
+		//TODO: end of hack
 		String versionSemVer = spdxUri.substring("https://spdx.org/rdf/".length());
 		versionSemVer = versionSemVer.substring(0, versionSemVer.indexOf('/'));
 		return versionSemVer;

--- a/src/test/java/org/spdx/tools/model2java/ShaclToJavaTest.java
+++ b/src/test/java/org/spdx/tools/model2java/ShaclToJavaTest.java
@@ -43,7 +43,7 @@ public class ShaclToJavaTest extends TestCase {
 			try (InputStream is = new FileInputStream(MODEL_FILE_PATH)) {
 				OntModel model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM);
 				model.read(is, "", "Turtle");
-				otj = new ShaclToJava(model, "v3_0_1");
+				otj = new ShaclToJava(model, "v3_0_1", "3.0.1");
 				List<String> warnings = otj.generate(tempDir);
 				assertTrue(warnings.isEmpty());
 				Path aIPath = tempDir.toPath().resolve("src")

--- a/testResources/spdx-model-3-1.ttl
+++ b/testResources/spdx-model-3-1.ttl
@@ -1,20 +1,20 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://spdx.org/rdf/3.1/terms/Core/> .
-@prefix ns10: <https://spdx.org/rdf/3.1/terms/Hardware/> .
-@prefix ns2: <https://spdx.org/rdf/3.1/terms/FunctionalSafety/> .
-@prefix ns3: <https://spdx.org/rdf/3.1/terms/Dataset/> .
-@prefix ns4: <https://spdx.org/rdf/3.1/terms/Security/> .
-@prefix ns5: <https://spdx.org/rdf/3.1/terms/AI/> .
-@prefix ns6: <https://spdx.org/rdf/3.1/terms/Software/> .
-@prefix ns7: <https://spdx.org/rdf/3.1/terms/SupplyChain/> .
-@prefix ns8: <https://spdx.org/rdf/3.1/terms/Service/> .
-@prefix ns9: <https://spdx.org/rdf/3.1/terms/ExpandedLicensing/> .
+@prefix ns1: <https://spdx.org/rdf/3/terms/Core/> .
+@prefix ns10: <https://spdx.org/rdf/3/terms/ExpandedLicensing/> .
+@prefix ns2: <https://spdx.org/rdf/3/terms/FunctionalSafety/> .
+@prefix ns3: <https://spdx.org/rdf/3/terms/Hardware/> .
+@prefix ns4: <https://spdx.org/rdf/3/terms/Software/> .
+@prefix ns5: <https://spdx.org/rdf/3/terms/Security/> .
+@prefix ns6: <https://spdx.org/rdf/3/terms/Dataset/> .
+@prefix ns7: <https://spdx.org/rdf/3/terms/AI/> .
+@prefix ns8: <https://spdx.org/rdf/3/terms/Service/> .
+@prefix ns9: <https://spdx.org/rdf/3/terms/SupplyChain/> .
 @prefix omg-ann: <https://www.omg.org/spec/Commons/AnnotationVocabulary/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix spdx: <https://spdx.org/rdf/3.1/terms/> .
+@prefix spdx: <https://spdx.org/rdf/3/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ns1:NoAssertionElement a owl:NamedIndividual,
@@ -29,37 +29,37 @@ ns1:NoneElement a owl:NamedIndividual,
 cardinality (number/count) of zero."""@en ;
     ns1:creationInfo <https://spdx.org/rdf/3.1/creationInfo_NoneElement> .
 
-ns9:NoAssertionLicense a owl:NamedIndividual,
-        ns9:IndividualLicensingInfo ;
+ns10:NoAssertionLicense a owl:NamedIndividual,
+        ns10:IndividualLicensingInfo ;
     rdfs:comment """An Individual Value for License when no assertion can be made about its actual
 value."""@en ;
-    owl:sameAs <https://spdx.org/rdf/3.1/terms/Licensing/NoAssertion> ;
+    owl:sameAs <https://spdx.org/rdf/3/terms/Licensing/NoAssertion> ;
     ns1:creationInfo <https://spdx.org/rdf/3.1/creationInfo_NoAssertionLicense> .
 
-ns9:NoneLicense a owl:NamedIndividual,
-        ns9:IndividualLicensingInfo ;
+ns10:NoneLicense a owl:NamedIndividual,
+        ns10:IndividualLicensingInfo ;
     rdfs:comment """An Individual Value for License where the SPDX data creator determines that no
 license is present."""@en ;
-    owl:sameAs <https://spdx.org/rdf/3.1/terms/Licensing/None> ;
+    owl:sameAs <https://spdx.org/rdf/3/terms/Licensing/None> ;
     ns1:creationInfo <https://spdx.org/rdf/3.1/creationInfo_NoneLicense> .
 
-<https://spdx.org/rdf/3.1/terms/Extension/CdxPropertiesExtension> a owl:Class,
+<https://spdx.org/rdf/3/terms/Extension/CdxPropertiesExtension> a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A type of extension consisting of a list of name value pairs."@en ;
-    rdfs:subClassOf <https://spdx.org/rdf/3.1/terms/Extension/Extension> ;
+    rdfs:subClassOf <https://spdx.org/rdf/3/terms/Extension/Extension> ;
     sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:class <https://spdx.org/rdf/3.1/terms/Extension/CdxPropertyEntry> ;
+    sh:property [ sh:class <https://spdx.org/rdf/3/terms/Extension/CdxPropertyEntry> ;
             sh:minCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Extension/cdxProperty> ] .
+            sh:path <https://spdx.org/rdf/3/terms/Extension/cdxProperty> ] .
 
-ns10:mass a owl:DatatypeProperty ;
+ns3:mass a owl:DatatypeProperty ;
     rdfs:comment "Information related to physical hardware."@en ;
     rdfs:range xsd:decimal .
 
-<https://spdx.org/rdf/3.1/terms/Operations/exportControlClassificationResult> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Operations/exportControlClassificationResult> a owl:DatatypeProperty ;
     rdfs:comment "Provides the result of an export control assessment."@en ;
-    rdfs:range <https://spdx.org/rdf/3.1/terms/Operations/ExportControlClassification> .
+    rdfs:range <https://spdx.org/rdf/3/terms/Operations/ExportControlClassification> .
 
 <https://spdx.org/rdf/3.1/creationInfo_NoAssertionElement> a ns1:CreationInfo ;
     rdfs:comment "This individual element was defined by the spec."@en ;
@@ -102,108 +102,108 @@ spdx: a owl:Ontology ;
     owl:versionIRI spdx: ;
     omg-ann:copyright "Copyright (C) 2026 SPDX Project"@en .
 
-ns5:AIPackage a owl:Class,
+ns7:AIPackage a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A Package that contains AI software or an AI model."@en ;
-    rdfs:subClassOf ns6:Package ;
+    rdfs:subClassOf ns4:Package ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns5:SafetyRiskAssessmentType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/AI/SafetyRiskAssessmentType/serious> <https://spdx.org/rdf/3.1/terms/AI/SafetyRiskAssessmentType/high> <https://spdx.org/rdf/3.1/terms/AI/SafetyRiskAssessmentType/medium> <https://spdx.org/rdf/3.1/terms/AI/SafetyRiskAssessmentType/low> ) ;
+    sh:property [ sh:class ns1:DictionaryEntry ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns7:metricDecisionThreshold ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns7:limitation ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns7:modelDataPreprocessing ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns7:modelExplainability ],
+        [ sh:class ns7:SafetyRiskAssessmentType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/AI/SafetyRiskAssessmentType/serious> <https://spdx.org/rdf/3/terms/AI/SafetyRiskAssessmentType/high> <https://spdx.org/rdf/3/terms/AI/SafetyRiskAssessmentType/medium> <https://spdx.org/rdf/3/terms/AI/SafetyRiskAssessmentType/low> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns5:safetyRiskAssessment ],
+            sh:path ns7:safetyRiskAssessment ],
         [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:path ns5:modelDataPreprocessing ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns5:typeOfModel ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns5:informationAboutApplication ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns5:informationAboutTraining ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns5:limitation ],
-        [ sh:class ns1:PresenceType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/PresenceType/yes> <https://spdx.org/rdf/3.1/terms/Core/PresenceType/no> <https://spdx.org/rdf/3.1/terms/Core/PresenceType/noAssertion> ) ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns5:useSensitivePersonalInformation ],
+            sh:path ns7:typeOfModel ],
         [ sh:class ns1:DictionaryEntry ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns5:metricDecisionThreshold ],
+            sh:path ns7:metric ],
+        [ sh:class ns1:PresenceType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/PresenceType/yes> <https://spdx.org/rdf/3/terms/Core/PresenceType/no> <https://spdx.org/rdf/3/terms/Core/PresenceType/noAssertion> ) ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns7:useSensitivePersonalInformation ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns7:standardCompliance ],
+        [ sh:class ns1:DictionaryEntry ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns7:hyperparameter ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns7:informationAboutTraining ],
+        [ sh:class ns7:EnergyConsumption ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns7:energyConsumption ],
+        [ sh:class ns1:PresenceType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/PresenceType/yes> <https://spdx.org/rdf/3/terms/Core/PresenceType/no> <https://spdx.org/rdf/3/terms/Core/PresenceType/noAssertion> ) ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns7:autonomyType ],
         [ sh:class ns1:IsoAutomationLevel ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/autonomous> <https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/fullAutomation> <https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/highAutomation> <https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/conditionalAutomation> <https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/partialAutomation> <https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/assistiveAutomation> <https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/notAutomated> ) ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/autonomous> <https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/fullAutomation> <https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/highAutomation> <https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/conditionalAutomation> <https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/partialAutomation> <https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/assistiveAutomation> <https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/notAutomated> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:path ns1:isoAutomationLevel ],
-        [ sh:class ns1:DictionaryEntry ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns5:metric ],
-        [ sh:class ns1:PresenceType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/PresenceType/yes> <https://spdx.org/rdf/3.1/terms/Core/PresenceType/no> <https://spdx.org/rdf/3.1/terms/Core/PresenceType/noAssertion> ) ;
+        [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns5:autonomyType ],
-        [ sh:class ns1:DictionaryEntry ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns5:hyperparameter ],
-        [ sh:class ns5:EnergyConsumption ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns5:energyConsumption ],
+            sh:nodeKind sh:Literal ;
+            sh:path ns7:informationAboutApplication ],
         [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:path ns5:standardCompliance ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns5:modelExplainability ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns5:domain ] .
+            sh:path ns7:domain ] .
 
-<https://spdx.org/rdf/3.1/terms/AI/EnergyUnitType/kilowattHour> a owl:NamedIndividual,
-        ns5:EnergyUnitType ;
+<https://spdx.org/rdf/3/terms/AI/EnergyUnitType/kilowattHour> a owl:NamedIndividual,
+        ns7:EnergyUnitType ;
     rdfs:label "kilowattHour" ;
     rdfs:comment "Kilowatt-hour."@en .
 
-<https://spdx.org/rdf/3.1/terms/AI/EnergyUnitType/megajoule> a owl:NamedIndividual,
-        ns5:EnergyUnitType ;
+<https://spdx.org/rdf/3/terms/AI/EnergyUnitType/megajoule> a owl:NamedIndividual,
+        ns7:EnergyUnitType ;
     rdfs:label "megajoule" ;
     rdfs:comment "Megajoule."@en .
 
-<https://spdx.org/rdf/3.1/terms/AI/EnergyUnitType/other> a owl:NamedIndividual,
-        ns5:EnergyUnitType ;
+<https://spdx.org/rdf/3/terms/AI/EnergyUnitType/other> a owl:NamedIndividual,
+        ns7:EnergyUnitType ;
     rdfs:label "other" ;
     rdfs:comment "Any other units of energy measurement."@en .
 
-<https://spdx.org/rdf/3.1/terms/AI/SafetyRiskAssessmentType/high> a owl:NamedIndividual,
-        ns5:SafetyRiskAssessmentType ;
+<https://spdx.org/rdf/3/terms/AI/SafetyRiskAssessmentType/high> a owl:NamedIndividual,
+        ns7:SafetyRiskAssessmentType ;
     rdfs:label "high" ;
     rdfs:comment "The second-highest level of risk posed by an AI system."@en .
 
-<https://spdx.org/rdf/3.1/terms/AI/SafetyRiskAssessmentType/low> a owl:NamedIndividual,
-        ns5:SafetyRiskAssessmentType ;
+<https://spdx.org/rdf/3/terms/AI/SafetyRiskAssessmentType/low> a owl:NamedIndividual,
+        ns7:SafetyRiskAssessmentType ;
     rdfs:label "low" ;
     rdfs:comment "Low/no risk is posed by an AI system."@en .
 
-<https://spdx.org/rdf/3.1/terms/AI/SafetyRiskAssessmentType/medium> a owl:NamedIndividual,
-        ns5:SafetyRiskAssessmentType ;
+<https://spdx.org/rdf/3/terms/AI/SafetyRiskAssessmentType/medium> a owl:NamedIndividual,
+        ns7:SafetyRiskAssessmentType ;
     rdfs:label "medium" ;
     rdfs:comment "The third-highest level of risk posed by an AI system."@en .
 
-<https://spdx.org/rdf/3.1/terms/AI/SafetyRiskAssessmentType/serious> a owl:NamedIndividual,
-        ns5:SafetyRiskAssessmentType ;
+<https://spdx.org/rdf/3/terms/AI/SafetyRiskAssessmentType/serious> a owl:NamedIndividual,
+        ns7:SafetyRiskAssessmentType ;
     rdfs:label "serious" ;
     rdfs:comment "The highest level of risk posed by an AI system."@en .
 
-ns5:autonomyType a owl:ObjectProperty ;
+ns7:autonomyType a owl:ObjectProperty ;
     rdfs:comment """**DEPRECATED in SPDX 3.1.**
 Use [/Core/isoAutomationLevel](../../Core/Properties/isoAutomationLevel.md)
 instead.
@@ -212,163 +212,179 @@ Indicates whether the system can perform a decision or action without human
 involvement or guidance."""@en ;
     rdfs:range ns1:PresenceType .
 
-ns5:domain a owl:DatatypeProperty ;
+ns7:domain a owl:DatatypeProperty ;
     rdfs:comment "Domain in which the AI package can be used."@en ;
     rdfs:range xsd:string .
 
-ns5:energyConsumption a owl:ObjectProperty ;
+ns7:energyConsumption a owl:ObjectProperty ;
     rdfs:comment "Energy consumption incurred by an AI model."@en ;
-    rdfs:range ns5:EnergyConsumption .
+    rdfs:range ns7:EnergyConsumption .
 
-ns5:energyQuantity a owl:DatatypeProperty ;
+ns7:energyQuantity a owl:DatatypeProperty ;
     rdfs:comment "Energy quantity."@en ;
     rdfs:range xsd:decimal .
 
-ns5:energyUnit a owl:ObjectProperty ;
+ns7:energyUnit a owl:ObjectProperty ;
     rdfs:comment "Unit in which energy is measured."@en ;
-    rdfs:range ns5:EnergyUnitType .
+    rdfs:range ns7:EnergyUnitType .
 
-ns5:finetuningEnergyConsumption a owl:ObjectProperty ;
+ns7:finetuningEnergyConsumption a owl:ObjectProperty ;
     rdfs:comment """Energy consumed when finetuning the AI model that is
 being used in the AI system."""@en ;
-    rdfs:range ns5:EnergyConsumptionDescription .
+    rdfs:range ns7:EnergyConsumptionDescription .
 
-ns5:hyperparameter a owl:ObjectProperty ;
+ns7:hyperparameter a owl:ObjectProperty ;
     rdfs:comment "Hyperparameter used to build the AI model contained in the AI package."@en ;
     rdfs:range ns1:DictionaryEntry .
 
-ns5:inferenceEnergyConsumption a owl:ObjectProperty ;
+ns7:inferenceEnergyConsumption a owl:ObjectProperty ;
     rdfs:comment """Energy consumed during inference time by an AI model
 that is being used in the AI system."""@en ;
-    rdfs:range ns5:EnergyConsumptionDescription .
+    rdfs:range ns7:EnergyConsumptionDescription .
 
-ns5:informationAboutApplication a owl:DatatypeProperty ;
+ns7:informationAboutApplication a owl:DatatypeProperty ;
     rdfs:comment "Information about the AI software, not including the model description."@en ;
     rdfs:range xsd:string .
 
-ns5:informationAboutTraining a owl:DatatypeProperty ;
+ns7:informationAboutTraining a owl:DatatypeProperty ;
     rdfs:comment "Information about different steps of the training process."@en ;
     rdfs:range xsd:string .
 
-ns5:limitation a owl:DatatypeProperty ;
+ns7:limitation a owl:DatatypeProperty ;
     rdfs:comment "Limitation of the AI software."@en ;
     rdfs:range xsd:string .
 
-ns5:metric a owl:ObjectProperty ;
+ns7:metric a owl:ObjectProperty ;
     rdfs:comment "Metric used to evaluate the AI model."@en ;
     rdfs:range ns1:DictionaryEntry .
 
-ns5:metricDecisionThreshold a owl:ObjectProperty ;
+ns7:metricDecisionThreshold a owl:ObjectProperty ;
     rdfs:comment """Threshold that was used for computation of a metric described in
 the metric field."""@en ;
     rdfs:range ns1:DictionaryEntry .
 
-ns5:modelDataPreprocessing a owl:DatatypeProperty ;
+ns7:modelDataPreprocessing a owl:DatatypeProperty ;
     rdfs:comment "Preprocessing steps applied to the training data before the model training."@en ;
     rdfs:range xsd:string .
 
-ns5:modelExplainability a owl:DatatypeProperty ;
+ns7:modelExplainability a owl:DatatypeProperty ;
     rdfs:comment "Methods that can be used to explain the results from the AI model."@en ;
     rdfs:range xsd:string .
 
-ns5:safetyRiskAssessment a owl:ObjectProperty ;
+ns7:safetyRiskAssessment a owl:ObjectProperty ;
     rdfs:comment "Results of general safety risk assessment of the AI system."@en ;
-    rdfs:range ns5:SafetyRiskAssessmentType .
+    rdfs:range ns7:SafetyRiskAssessmentType .
 
-ns5:standardCompliance a owl:DatatypeProperty ;
-    rdfs:comment "Standard that an artifact is being complied with."@en ;
+ns7:standardCompliance a owl:DatatypeProperty ;
+    rdfs:comment "A standard with which the artifact complies."@en ;
     rdfs:range xsd:string .
 
-ns5:trainingEnergyConsumption a owl:ObjectProperty ;
+ns7:trainingEnergyConsumption a owl:ObjectProperty ;
     rdfs:comment """Energy consumed when training the AI model that is
 being used in the AI system."""@en ;
-    rdfs:range ns5:EnergyConsumptionDescription .
+    rdfs:range ns7:EnergyConsumptionDescription .
 
-ns5:typeOfModel a owl:DatatypeProperty ;
+ns7:typeOfModel a owl:DatatypeProperty ;
     rdfs:comment "Type of the model used in the AI software."@en ;
     rdfs:range xsd:string .
 
-ns5:useSensitivePersonalInformation a owl:ObjectProperty ;
+ns7:useSensitivePersonalInformation a owl:ObjectProperty ;
     rdfs:comment """Records if sensitive personal information is used during model training or
 could be used during the inference."""@en ;
     rdfs:range ns1:PresenceType .
 
-<https://spdx.org/rdf/3.1/terms/Build/Build> a owl:Class,
+<https://spdx.org/rdf/3/terms/Build/Build> a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Class that describes a build instance of software/artifacts."@en ;
     rdfs:subClassOf ns1:Element ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:DictionaryEntry ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Build/parameter> ],
-        [ sh:class ns1:DictionaryEntry ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Build/environment> ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Build/configSourceEntrypoint> ],
-        [ sh:datatype xsd:string ;
+    sh:property [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Build/buildId> ],
+            sh:path ns1:startTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path <https://spdx.org/rdf/3/terms/Build/buildEndTime> ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path <https://spdx.org/rdf/3/terms/Build/configSourceEntrypoint> ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:endTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path <https://spdx.org/rdf/3/terms/Build/buildStartTime> ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:class ns1:DictionaryEntry ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <https://spdx.org/rdf/3/terms/Build/parameter> ],
+        [ sh:class ns1:Hash ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <https://spdx.org/rdf/3/terms/Build/configSourceDigest> ],
+        [ sh:datatype xsd:anyURI ;
+            sh:nodeKind sh:Literal ;
+            sh:path <https://spdx.org/rdf/3/terms/Build/configSourceUri> ],
         [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Build/buildType> ],
-        [ sh:datatype xsd:anyURI ;
-            sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Build/configSourceUri> ],
-        [ sh:datatype xsd:dateTimeStamp ;
+            sh:path <https://spdx.org/rdf/3/terms/Build/buildType> ],
+        [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Build/buildStartTime> ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:class ns1:Hash ;
+            sh:path <https://spdx.org/rdf/3/terms/Build/buildId> ],
+        [ sh:class ns1:DictionaryEntry ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Build/configSourceDigest> ],
-        [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Build/buildEndTime> ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ] .
+            sh:path <https://spdx.org/rdf/3/terms/Build/environment> ] .
 
-<https://spdx.org/rdf/3.1/terms/Build/buildEndTime> a owl:DatatypeProperty ;
-    rdfs:comment "Property that describes the time at which a build stops."@en ;
+<https://spdx.org/rdf/3/terms/Build/buildEndTime> a owl:DatatypeProperty ;
+    rdfs:comment """**DEPRECATED in SPDX 3.1.**
+Use [/Core/endTime](../../Core/Properties/endTime.md) instead.
+
+Property that describes the time at which a build stops."""@en ;
     rdfs:range xsd:dateTimeStamp .
 
-<https://spdx.org/rdf/3.1/terms/Build/buildId> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Build/buildId> a owl:DatatypeProperty ;
     rdfs:comment """A buildId is a locally unique identifier used by a builder to identify a unique
 instance of a build produced by it."""@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/Build/buildStartTime> a owl:DatatypeProperty ;
-    rdfs:comment "Property describing the start time of a build."@en ;
+<https://spdx.org/rdf/3/terms/Build/buildStartTime> a owl:DatatypeProperty ;
+    rdfs:comment """**DEPRECATED in SPDX 3.1.**
+Use [/Core/startTime](../../Core/Properties/startTime.md) instead.
+
+Property describing the start time of a build."""@en ;
     rdfs:range xsd:dateTimeStamp .
 
-<https://spdx.org/rdf/3.1/terms/Build/buildType> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Build/buildType> a owl:DatatypeProperty ;
     rdfs:comment """A buildType is a hint that is used to indicate the toolchain, platform, or
 infrastructure that the build was invoked on."""@en ;
     rdfs:range xsd:anyURI .
 
-<https://spdx.org/rdf/3.1/terms/Build/configSourceDigest> a owl:ObjectProperty ;
+<https://spdx.org/rdf/3/terms/Build/configSourceDigest> a owl:ObjectProperty ;
     rdfs:comment """Property that describes the digest of the build configuration file used to
 invoke a build."""@en ;
     rdfs:range ns1:Hash .
 
-<https://spdx.org/rdf/3.1/terms/Build/configSourceEntrypoint> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Build/configSourceEntrypoint> a owl:DatatypeProperty ;
     rdfs:comment "Property describes the invocation entrypoint of a build."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/Build/configSourceUri> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Build/configSourceUri> a owl:DatatypeProperty ;
     rdfs:comment "Property that describes the URI of the build configuration source file."@en ;
     rdfs:range xsd:anyURI .
 
-<https://spdx.org/rdf/3.1/terms/Build/environment> a owl:ObjectProperty ;
+<https://spdx.org/rdf/3/terms/Build/environment> a owl:ObjectProperty ;
     rdfs:comment "Property describing the session in which a build is invoked."@en ;
     rdfs:range ns1:DictionaryEntry .
 
-<https://spdx.org/rdf/3.1/terms/Build/parameter> a owl:ObjectProperty ;
+<https://spdx.org/rdf/3/terms/Build/parameter> a owl:ObjectProperty ;
     rdfs:comment "Property describing a parameter used in an instance of a build."@en ;
     rdfs:range ns1:DictionaryEntry .
 
@@ -387,7 +403,7 @@ ns1:Annotation a owl:Class,
             sh:path ns1:contentType ;
             sh:pattern "^[^\\/]+\\/[^\\/]+$" ],
         [ sh:class ns1:AnnotationType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/AnnotationType/other> <https://spdx.org/rdf/3.1/terms/Core/AnnotationType/review> ) ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/AnnotationType/other> <https://spdx.org/rdf/3/terms/Core/AnnotationType/review> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
@@ -398,12 +414,12 @@ ns1:Annotation a owl:Class,
             sh:nodeKind sh:IRI ;
             sh:path ns1:subject ] .
 
-<https://spdx.org/rdf/3.1/terms/Core/AnnotationType/other> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/AnnotationType/other> a owl:NamedIndividual,
         ns1:AnnotationType ;
     rdfs:label "other" ;
     rdfs:comment "Used to store extra information about an Element which is not part of a review (e.g. extra information provided during the creation of the Element)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/AnnotationType/review> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/AnnotationType/review> a owl:NamedIndividual,
         ns1:AnnotationType ;
     rdfs:label "review" ;
     rdfs:comment "Used when someone reviews the Element."@en .
@@ -414,408 +430,533 @@ ns1:ContactPointRelationship a owl:Class,
     rdfs:subClassOf ns1:Relationship ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:class ns1:ContactPointRelationshipType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/ContactPointRelationshipType/compliance> <https://spdx.org/rdf/3.1/terms/Core/ContactPointRelationshipType/other> <https://spdx.org/rdf/3.1/terms/Core/ContactPointRelationshipType/securityVulnerability> <https://spdx.org/rdf/3.1/terms/Core/ContactPointRelationshipType/support> ) ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/ContactPointRelationshipType/compliance> <https://spdx.org/rdf/3/terms/Core/ContactPointRelationshipType/other> <https://spdx.org/rdf/3/terms/Core/ContactPointRelationshipType/securityVulnerability> <https://spdx.org/rdf/3/terms/Core/ContactPointRelationshipType/support> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:path ns1:contactType ] .
 
-<https://spdx.org/rdf/3.1/terms/Core/ContactPointRelationshipType/compliance> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ContactPointRelationshipType/compliance> a owl:NamedIndividual,
         ns1:ContactPointRelationshipType ;
     rdfs:label "compliance" ;
     rdfs:comment "A contact point for compliance (i.e. export control, licensing)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ContactPointRelationshipType/other> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ContactPointRelationshipType/other> a owl:NamedIndividual,
         ns1:ContactPointRelationshipType ;
     rdfs:label "other" ;
     rdfs:comment "A generic contact point to be used when the contact type does not match any of the other options."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ContactPointRelationshipType/securityVulnerability> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ContactPointRelationshipType/securityVulnerability> a owl:NamedIndividual,
         ns1:ContactPointRelationshipType ;
     rdfs:label "securityVulnerability" ;
     rdfs:comment "A contact for reporting security vulnerabilities."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ContactPointRelationshipType/support> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ContactPointRelationshipType/support> a owl:NamedIndividual,
         ns1:ContactPointRelationshipType ;
     rdfs:label "support" ;
     rdfs:comment "A contact point for support."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/cpe22> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/ark> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "ark" ;
+    rdfs:comment "[Archival Resource Key (ARK)](https://arks.org/about/), is a Uniform Resource Identifier (URI) suited to being a persistent identifier for information objects of any type, standardized by the [ARK Identifier Scheme](https://datatracker.ietf.org/doc/draft-kunze-ark/) Internet-Draft. It consists of the \"ark:\" label followed by a Name Assigning Authority Number, a forward slash, a name, and an optional qualifier (e.g., `ark:12148/btv1b8449691v/f29`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/bic> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "bic" ;
+    rdfs:comment "Business Identifier Code (BIC), also known as SWIFT-BIC or SWIFT code, is a unique 8 or 11-character alphanumeric code standardized by [ISO 9362](https://www.iso.org/standard/84108.html) to identify financial and non-financial institutions (e.g., `BBWCUS33`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/cpe22> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "cpe22" ;
     rdfs:comment "[Common Platform Enumeration Specification 2.2](https://cpe.mitre.org/files/cpe-specification_2.2.pdf)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/cpe23> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/cpe23> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "cpe23" ;
     rdfs:comment "[Common Platform Enumeration: Naming Specification Version 2.3](https://csrc.nist.gov/publications/detail/nistir/7695/final)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/cve> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/cve> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "cve" ;
     rdfs:comment "Common Vulnerabilities and Exposures identifiers, an identifier for a specific software flaw defined within the official CVE Dictionary and that conforms to the [CVE specification](https://csrc.nist.gov/glossary/term/cve_id)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/duns> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/doi> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "doi" ;
+    rdfs:comment "[Digital Object Identifier (DOI)](https://www.doi.org/the-identifier/what-is-a-doi/) is a unique, [ISO 26324](https://www.iso.org/standard/88862.html)-standardized identifier for physical, digital, or abstract objects, formatted as a prefix and suffix separated by a forward slash (e.g., `10.1000/182`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/duns> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "duns" ;
     rdfs:comment "[Data Universal Numbering System (D-U-N-S) Number](https://www.dnb.com/en-us/smb/duns.html) is a unique nine-digit identifier, issued by Dun & Bradstreet, that identifies a business entity, often on a location-specific basis."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/email> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/ecli> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "ecli" ;
+    rdfs:comment "[European Case Law Identifier (ECLI)](https://data.europa.eu/data/datasets/european-case-law-identifier-ecli) is a uniform identifier for judicial decisions across Europe. It consists of five mandatory components: the \"ECLI\" prefix, a country code, a court code, the year of the decision, and a unique serial number (e.g., `ECLI:EU:C:2023:94`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/eli> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "eli" ;
+    rdfs:comment "[European Legislation Identifier (ELI)](https://eur-lex.europa.eu/content/help/eurlex-content/eli.html) is a Uniform Resource Identifier (URI) that uniquely identifies a legal resource, typically consisting of a document type, adoption year, and document number (e.g., `http://data.europa.eu/eli/reg/2024/2847/oj`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/email> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "email" ;
     rdfs:comment "Email address, as defined in [RFC 3696](https://datatracker.ietf.org/doc/rfc3696/) Section 3."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/evidenceUUID> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/eori> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
-    rdfs:label "evidenceUUID" ;
-    rdfs:comment "The UUID used by a reporting management system or any other lifecycle management tool to uniquely identify an evidence relationship item. UUID, or universally unique ID, is a standard term to refer to evidence items."@en .
+    rdfs:label "eori" ;
+    rdfs:comment "[Economic Operators Registration and Identification (EORI) number](https://taxation-customs.ec.europa.eu/customs/customs-procedures-import-and-export/customs-operations/economic-operators-registration-and-identification-number-eori_en) is a unique identifier for businesses undertaking customs operations across European Union customs territory, such as import, export, and transit. It consists of an ISO 3166-1 alpha-2 country code followed by a national identifier of up to 15 alphanumeric characters (e.g., `PL1234567890ABCDE`)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/gitoid> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/evidenceUID> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "evidenceUID" ;
+    rdfs:comment "The unique identifier used by a reporting management system or any other lifecycle management tool to uniquely identify an evidence relationship item."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/gitoid> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "gitoid" ;
     rdfs:comment "[Gitoid](https://www.iana.org/assignments/uri-schemes/prov/gitoid), stands for [Git Object ID](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects). A gitoid of type blob is a unique hash of a binary artifact. A gitoid may represent either an [Artifact Identifier](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#artifact-identifier-types) for the software artifact or an [Input Manifest Identifier](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#input-manifest-identifier) for the software artifact's associated [Artifact Input Manifest](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#artifact-input-manifest); this ambiguity exists because the Artifact Input Manifest is itself an artifact, and the gitoid of that artifact is its valid identifier. Gitoids calculated on software artifacts (Snippet, File, or Package Elements) should be recorded in the SPDX 3 SoftwareArtifact's contentIdentifier property. Gitoids calculated on the Artifact Input Manifest (Input Manifest Identifier) should be recorded in the SPDX 3 Element's externalIdentifier property. See [OmniBOR Specification](https://github.com/omnibor/spec/), a minimalistic specification for describing software [Artifact Dependency Graphs](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#artifact-dependency-graph-adg)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/gln> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/gln> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "gln" ;
     rdfs:comment "[Global Location Number (GLN)](https://www.gs1.org/standards/id-keys/gln) is a 13-digit number, assigned by GS1, that uniquely identifies a legal entity (e.g., a company or customer), a function within a legal entity, a physical location (e.g., a warehouse or a specific shelf in a store), or a digital location (e.g., an Electronic Data Interchange (EDI) gateway)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/glue> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/glue> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "glue" ;
     rdfs:comment "[GLobal Unique Enterprise (GLUE) Identifiers](https://datatracker.ietf.org/doc/draft-ietf-spice-glue-id/), as defined by the IETF Internet-Draft, is expressed as a GLUE URI, a Uniform Resource Identifier that standardizes the representation of existing organizational entity identifiers."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/gtin> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/gtin> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "gtin" ;
     rdfs:comment "[Global Trade Item Number (GTIN)](https://www.gs1.org/standards/id-keys/gtin) is a number, assigned by GS1, that uniquely identifies a trade item (product or service)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/hsCodes> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/hsCodes> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "hsCodes" ;
     rdfs:comment "The [Harmonized System (HS)](https://www.wcoomd.org/en/topics/nomenclature/overview/what-is-the-harmonized-system.aspx) of tariff nomenclature is an internationally standardized system of names and numbers, defined by the World Customs Organization, used to classify traded products."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/lei> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/iban> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "iban" ;
+    rdfs:comment "International Bank Account Number (IBAN) is a system for identifying bank accounts across national borders standardized by [ISO 13616](https://www.iso.org/standard/81090.html). It consists of up to 34 alphanumeric characters, including a country code, two check digits, and a basic bank account number. While spaces may be inserted for human readability, they must be omitted when used for electronic data exchange (e.g., `IE64IRCE92050112345678`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/ibid> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "ibid" ;
+    rdfs:comment "[International Business Identifier (IBID)](https://ekys.org/business_identifiers/) is a verifiable unique identifier for legal entities as defined in the [ISO/DIS 25500-3](https://www.iso.org/standard/87705.html) draft standard. It is composed of three data elements: the International Business Registration Number (IBRN), the legal name, and the date of origin formatted as eight numeric characters (YYYYMMDD). Each element is separated by a pipe character (`|`) (e.g., `US-DE.BER:3031657|Code Management Association|19990420`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/ibrn> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "ibrn" ;
+    rdfs:comment "[International Business Registration Number (IBRN)](https://ekys.org/business_identifiers/) is a unique identifier for legal entities standardized by [ISO 8000-116](https://www.iso.org/standard/75117.html). It is composed of two parts: a jurisdiction prefix and a local authoritative legal entity identifier (ALEI), separated by a colon. The prefix contains an ISO 3166 country code, an optional subdivision code, and a register code (e.g., `US-DE.BER:3031657`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/isan> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "isan" ;
+    rdfs:comment "[International Standard Audiovisual Number (ISAN)](https://www.isan.org/about/#what_is_isan) is a unique 24-digit hexadecimal identifier for audiovisual works standardized by [ISO 15706](https://www.iso.org/standard/83124.html). The ISAN remains persistent for a work regardless of its distribution format or its use. To facilitate human readability, the \"ISAN\" label, grouping hyphens, and two check characters are included (e.g., `ISAN 0000-0000-3A8D-0000-Z-0000-0000-6`); however, these elements shall be omitted when the identifier is stored electronically (e.g., `000000003A8D000000000000`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/isbn> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "isbn" ;
+    rdfs:comment "[International Standard Book Number (ISBN)](https://www.isbn-international.org/content/isbn-users-manual/29) is a unique numeric identifier for monographic publications standardized by [ISO 2108](https://www.iso.org/standard/65483.html). It consists of either 10 digits (for assignments prior to January 1, 2007) or 13 digits. A 13-digit ISBN is composed of five parts: a GS1 prefix, a registration group, a registrant, a publication element, and a check digit. While elements may be divided by spaces or hyphens for human readability, these separators shall be omitted when the identifier is stored electronically (e.g., `9780198836063`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/iscc> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "iscc" ;
+    rdfs:comment "[International Standard Content Code (ISCC)](https://iscc.io/) is a content-derived identifier standardized by [ISO 24138](https://www.iso.org/standard/77899.html) for identifying digital assets. ISCC can be used in conjunction with other schemes, such as DOI, ISAN, ISBN, ISRC, ISSN and ISWC. A standard ISCC-CODE is build from multiple ISCC-UNITs. Each unit serve a different purpose. An ISCC-CODE typically look like `ISCC:KACT4EBWK27737D2AYCJRAL5Z36G76RFRMO4554RU26HZ4ORJGIVHDI`."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/isci> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "isci" ;
+    rdfs:comment "International Standard Collection Identifier (ISCI) is a variable-length identifier standardized by [ISO 27730](https://www.iso.org/standard/44293.html) for identifying collections held by libraries, archives, museums, and other memory institutions. It consists of two parts: the identifier for the assigning organization (an ISIL) enclosed in square brackets, followed by a local collection identifier string (e.g., `[FR-751041001]Casadesus1`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/isil> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "isil" ;
+    rdfs:comment "[International Standard Identifier for Libraries and Related Organizations (ISIL)](https://slks.dk/english/work-areas/libraries-and-literature/library-standards/isil/) is a unique alphanumeric code for identifying libraries, archives, museums, and related organizations standardized by [ISO 15511](https://www.iso.org/standard/77849.html). It consists of a prefix—which may be an ISO 3166-1 alpha-2 country code or a non-country code assigned by the ISIL Registration Authority—followed by a unit identifier, totaling up to 16 characters (e.g., `FI-Sipoo-Sö` or `ZDB-1-SBD`). Valid symbols include any alphanumeric character, solidus (`/`), hyphen-minus (`-`), or colon."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/ismn> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "ismn" ;
+    rdfs:comment "[International Standard Music Number (ISMN)](https://ismn-international.org/ismn/the-ismn/) is a unique numeric identifier for printed music (notated music) standardized by [ISO 10957](https://www.iso.org/standard/83122.html). It consists of either 10 characters (starting with the letter \"M\" for assignments prior to January 1, 2008) or 13 digits. A 13-digit ISMN is composed of four parts: the GS1 prefix `979-0`, a registrant element, an item element, and a check digit. While elements may be divided by spaces or hyphens for human readability, these separators shall be omitted when the identifier is stored electronically (e.g., `9790006538424`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/isni> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "isni" ;
+    rdfs:comment "[International Standard Name Identifier (ISNI)](https://isni.org/page/what-is-isni/) is a unique identifier used to distinguish the public identities of parties involved in the creation, production, and distribution of media content. Standardized by [ISO 27729](https://www.iso.org/standard/87177.html), it consists of 16 characters—15 digits plus a final check character—and is often represented as a URI, such as `https://isni.org/isni/000000012146438X`."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/isrc> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "isrc" ;
+    rdfs:comment "[International Standard Recording Code (ISRC)](https://isrc.ifpi.org/isrc-standard) is a unique 12-character alphanumeric identifier for sound recordings and music video recordings standardized by [ISO 3901](https://www.iso.org/standard/64817.html). While the \"ISRC\" label and grouping hyphens used for human readability, they shall be omitted when the identifier is stored electronically (e.g., `USCA28900153`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/issn> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "issn" ;
+    rdfs:comment "[International Standard Serial Number (ISSN)](https://www.issn.org/understanding-the-issn/what-is-an-issn/) is an eight-digit identifier for serial publications and other continuing resources standardized by [ISO 3297](https://www.iso.org/standard/84536.html). It consists of two groups of four digits separated by a hyphen, where the final character is a check digit that may be an \"X\". The hyphen is retained when the identifier is stored electronically to maintain the standard 9-character string format (e.g., `1464-3693`). The ISSN is media-specific; the same journal title may be assigned different identifiers for its physical and digital versions."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/iswc> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "iswc" ;
+    rdfs:comment "[International Standard Musical Work Code (ISWC)](https://www.iswc.org/iswc) is an 11-character unique identifier standardized by [ISO 15707](https://www.iso.org/standard/83125.html) for musical works (compositions) as distinct from specific recordings. While the \"ISWC\" label and grouping separators (dots and hyphens) are used for human readability, they shall be omitted when the identifier is stored electronically (e.g., `T0017812031`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/lei> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "lei" ;
     rdfs:comment "The [Legal Entity Identifier (LEI)](https://www.gleif.org/en/organizational-identity/introducing-the-legal-entity-identifier-lei) is a 20-character, alphanumeric code based on the [ISO 17442](https://www.iso.org/standard/78829.html) standard developed by the International Organization for Standardization."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/other> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/lexid> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "lexid" ;
+    rdfs:comment "LEX Identifier is a Uniform Resource Name (URN) for sources of law within the [LEX namespace](https://www.iana.org/assignments/urn-formal/lex), as defined in [RFC 9676](https://datatracker.ietf.org/doc/rfc9676/) (e.g., `urn:lex:it:stato:decreto.legislativo:2018-08-10;101`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/nli> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "nli" ;
+    rdfs:comment "[Natural Location Identifier (NLI)](https://eccma.org/enli-eccma-natural-location-identifier/) is a 14- or 15-character alphanumeric string standardized by [ISO 8000-118](https://www.iso.org/standard/85428.html) that uniquely identifies a three-dimensional geographic point location. The identifier is generated from geodetic coordinates and elevation data. For electronic storage, the `ISO.NLI:` prefix shall be retained (e.g., `ISO.NLI:41TS8M-A8ELTQ-H2`)."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/orcidid> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "orcidid" ;
+    rdfs:comment "[Open Researcher and Contributor ID (ORCID) iD](https://info.orcid.org/what-is-orcid/) is a unique identifier for authors and contributors in scholarly communication; as a subset of the International Standard Name Identifier (ISNI), it typically appears as a URI such as `https://orcid.org/0000-0002-1825-0097`."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/other> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "other" ;
     rdfs:comment "Used when the type does not match any of the other options."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/packageUrl> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/packageUrl> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "packageUrl" ;
-    rdfs:comment "Package URL, as defined in the corresponding [Annex](../../../annexes/pkg-url-specification.md) of this document."@en .
+    rdfs:comment "Package-URL (PURL), as defined in [ECMA-427](https://ecma-international.org/publications-and-standards/standards/ecma-427/)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/phoneNumber> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/phoneNumber> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "phoneNumber" ;
     rdfs:comment "Phone number; A string of decimal digits that uniquely indicates the network termination point defined in [RFC 3966](https://datatracker.ietf.org/doc/rfc3966/) Section 5."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/requirementUUID> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/requirementUID> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
-    rdfs:label "requirementUUID" ;
-    rdfs:comment "The UUID used by a requirements management or any other lifecycle management tool to uniquely identify a requirement item. UUID, or universally unique ID, is a standard term in requirements engineering."@en .
+    rdfs:label "requirementUID" ;
+    rdfs:comment "The unique identifier used by a requirements management or any other lifecycle management tool to uniquely identify a requirement item."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/securityOther> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/rorid> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "rorid" ;
+    rdfs:comment "[Research Organization Registry (ROR) identifier](https://ror.org/about/) is a unique identifier for research and funding organization, typically expressed in its preferred URI form such as `https://ror.org/02mhbdp94`."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/securityOther> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "securityOther" ;
     rdfs:comment "Used when there is a security related identifier of unspecified type."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/swhid> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/swhid> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "swhid" ;
     rdfs:comment "SoftWare Hash IDentifier, a persistent intrinsic identifier for digital artifacts, such as files, trees (also known as directories or folders), commits, and other objects typically found in version control systems. The format of the identifiers is defined in the [SWHID specification](https://www.swhid.org/swhid-specification/v1.2/) ([ISO/IEC 18670](https://www.iso.org/standard/89985.html)). They typically look like `swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2`."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/swid> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/swid> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "swid" ;
     rdfs:comment "Concise Software Identification (CoSWID) tag, as defined in [RFC 9393](https://datatracker.ietf.org/doc/rfc9393/) Section 2.3."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/urlScheme> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/urlScheme> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "urlScheme" ;
     rdfs:comment "[Uniform Resource Identifier (URI) Schemes](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml). The scheme used in order to locate a resource."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/verificationUUID> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/vatNumber> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
-    rdfs:label "verificationUUID" ;
-    rdfs:comment "The UUID used by a verification management system or any other lifecycle management tool to uniquely identify a verification item. UUID, or universally unique ID, is a standard term to refer to verification items."@en .
+    rdfs:label "vatNumber" ;
+    rdfs:comment "Value Added Tax (VAT) number, or Goods and Services Tax (GST) number, is an identifier assigned by tax authorities that uniquely identifies a business within a specific national border or tax jurisdiction for the collection and tracking of VAT/GST."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/webpage> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/verificationUID> a owl:NamedIndividual,
+        ns1:ExternalIdentifierType ;
+    rdfs:label "verificationUID" ;
+    rdfs:comment "The unique identifier used by a verification management system or any other lifecycle management tool to uniquely identify a verification item."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/webpage> a owl:NamedIndividual,
         ns1:ExternalIdentifierType ;
     rdfs:label "webpage" ;
-    rdfs:comment "Absolute URL that can be used to locate a resource, as defined in [RFC 7230](https://datatracker.ietf.org/doc/rfc7230/) Section 2.7.1 or Section 2.7.2."@en .
+    rdfs:comment "A Uniform Resource Locator (URL) that can be used to locate a resource, as defined in [RFC 9110](https://datatracker.ietf.org/doc/rfc9110/) Section 4.2.1 or Section 4.2.2. It may include an optional fragment identifier as specified in [RFC 3986](https://datatracker.ietf.org/doc/rfc3986) Section 3.5."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/altDownloadLocation> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/altDownloadLocation> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "altDownloadLocation" ;
     rdfs:comment "A reference to an alternative download location."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/altWebPage> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/altWebPage> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "altWebPage" ;
     rdfs:comment "A reference to an alternative web page."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/binaryArtifact> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/binaryArtifact> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "binaryArtifact" ;
     rdfs:comment "A reference to binary artifacts related to a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/bower> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/bom> a owl:NamedIndividual,
+        ns1:ExternalRefType ;
+    rdfs:label "bom" ;
+    rdfs:comment "A reference to a bill of materials related to a package."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/bower> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "bower" ;
     rdfs:comment "A reference to a Bower package. The package locator format, looks like `package#version`, is defined in the \"install\" section of [Bower API documentation](https://bower.io/docs/api/#install)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/buildMeta> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/buildMeta> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "buildMeta" ;
-    rdfs:comment "A reference build metadata related to a published package."@en .
+    rdfs:comment "A reference to the build metadata related to a published package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/buildSystem> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/buildSystem> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "buildSystem" ;
-    rdfs:comment "A reference build system used to create or publish the package."@en .
+    rdfs:comment "A reference to the build system used to create or publish the package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/certificationReport> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/certificationReport> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "certificationReport" ;
     rdfs:comment "A reference to a certification report for a package from an accredited/independent body."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/chat> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/chat> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "chat" ;
     rdfs:comment "A reference to the instant messaging system used by the maintainer for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/componentAnalysisReport> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/componentAnalysisReport> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "componentAnalysisReport" ;
     rdfs:comment "A reference to a Software Composition Analysis (SCA) report."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/cwe> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/cwe> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "cwe" ;
-    rdfs:comment "[Common Weakness Enumeration](https://csrc.nist.gov/glossary/term/common_weakness_enumeration). A reference to a source of software flaw defined within the official [CWE List](https://cwe.mitre.org/data/) that conforms to the [CWE specification](https://cwe.mitre.org/)."@en .
+    rdfs:comment "[Common Weakness Enumeration](https://csrc.nist.gov/glossary/term/common_weakness_enumeration). A reference to a source of software flaws defined within the official [CWE List](https://cwe.mitre.org/data/) that conforms to the [CWE specification](https://cwe.mitre.org/)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/documentation> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/documentation> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "documentation" ;
     rdfs:comment "A reference to the documentation for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/dynamicAnalysisReport> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/dynamicAnalysisReport> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "dynamicAnalysisReport" ;
     rdfs:comment "A reference to a dynamic analysis report for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/eolNotice> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/eolNotice> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "eolNotice" ;
     rdfs:comment "A reference to the End Of Sale (EOS) and/or End Of Life (EOL) information related to a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/exportControlAssessment> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/exportControlAssessment> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "exportControlAssessment" ;
     rdfs:comment "A reference to an export control assessment for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/funding> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/funding> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "funding" ;
     rdfs:comment "A reference to funding information related to a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/issueTracker> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/issueTracker> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "issueTracker" ;
     rdfs:comment "A reference to the issue tracker for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/license> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/license> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "license" ;
     rdfs:comment "A reference to additional license information related to an artifact."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/mailingList> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/mailingList> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "mailingList" ;
     rdfs:comment "A reference to the mailing list used by the maintainer for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/mavenCentral> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/mavenCentral> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "mavenCentral" ;
     rdfs:comment "A reference to a Maven repository artifact. The artifact locator format is defined in the [Maven documentation](https://maven.apache.org/guides/mini/guide-naming-conventions.html) and looks like `groupId:artifactId[:version]`."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/metrics> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/metrics> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "metrics" ;
-    rdfs:comment "A reference to metrics related to package such as OpenSSF scorecards."@en .
+    rdfs:comment "A reference to metrics related to a package such as OpenSSF scorecards."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/npm> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/npm> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "npm" ;
     rdfs:comment "A reference to an npm package. The package locator format is defined in the [npm documentation](https://docs.npmjs.com/cli/v10/configuring-npm/package-json) and looks like `package@version`."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/nuget> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/nuget> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "nuget" ;
     rdfs:comment "A reference to a NuGet package. The package locator format is defined in the [NuGet documentation](https://docs.nuget.org) and looks like `package/version`."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/other> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/other> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "other" ;
     rdfs:comment "Used when the type does not match any of the other options."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/privacyAssessment> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/privacyAssessment> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "privacyAssessment" ;
     rdfs:comment "A reference to a privacy assessment for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/productMetadata> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/productMetadata> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "productMetadata" ;
-    rdfs:comment "A reference to additional product metadata such as reference within organization's product catalog."@en .
+    rdfs:comment "A reference to additional product metadata such as a reference within an organization's product catalog."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/purchaseOrder> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/purchaseOrder> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "purchaseOrder" ;
     rdfs:comment "A reference to a purchase order for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/qualityAssessmentReport> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/qualityAssessmentReport> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "qualityAssessmentReport" ;
     rdfs:comment "A reference to a quality assessment for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/releaseHistory> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/releaseHistory> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "releaseHistory" ;
     rdfs:comment "A reference to a published list of releases for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/releaseNotes> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/releaseNotes> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "releaseNotes" ;
     rdfs:comment "A reference to the release notes for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/riskAssessment> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/riskAssessment> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "riskAssessment" ;
     rdfs:comment "A reference to a risk assessment for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/runtimeAnalysisReport> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/runtimeAnalysisReport> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "runtimeAnalysisReport" ;
     rdfs:comment "A reference to a runtime analysis report for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/secureSoftwareAttestation> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/secureSoftwareAttestation> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "secureSoftwareAttestation" ;
     rdfs:comment "A reference to information assuring that the software is developed using security practices as defined by [NIST SP 800-218 Secure Software Development Framework (SSDF) Version 1.1](https://csrc.nist.gov/pubs/sp/800/218/final) or [CISA Secure Software Development Attestation Form](https://www.cisa.gov/resources-tools/resources/secure-software-development-attestation-form)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityAdversaryModel> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityAdversaryModel> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "securityAdversaryModel" ;
     rdfs:comment "A reference to the security adversary model for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityAdvisory> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityAdvisory> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "securityAdvisory" ;
-    rdfs:comment "A reference to a published security advisory (where advisory as defined per [ISO 29147:2018](https://www.iso.org/standard/72311.html)) that may affect one or more elements, e.g., vendor advisories or specific NVD entries."@en .
+    rdfs:comment "A reference to a published security advisory (where advisory is defined per [ISO 29147:2018](https://www.iso.org/standard/72311.html)) that may affect one or more elements, e.g., vendor advisories or specific NVD entries."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityFix> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityFix> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "securityFix" ;
     rdfs:comment "A reference to the patch or source code that fixes a vulnerability."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityOther> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityOther> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "securityOther" ;
     rdfs:comment "A reference to related security information of unspecified type."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityPenTestReport> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityPenTestReport> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "securityPenTestReport" ;
     rdfs:comment "A reference to a [penetration test](https://en.wikipedia.org/wiki/Penetration_test) report for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityPolicy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityPolicy> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "securityPolicy" ;
     rdfs:comment "A reference to instructions for reporting newly discovered security vulnerabilities for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityThreatModel> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityThreatModel> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "securityThreatModel" ;
-    rdfs:comment "A reference the [security threat model](https://en.wikipedia.org/wiki/Threat_model) for a package."@en .
+    rdfs:comment "A reference to the [security threat model](https://en.wikipedia.org/wiki/Threat_model) for the package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/socialMedia> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/socialMedia> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "socialMedia" ;
     rdfs:comment "A reference to a social media channel for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/sourceArtifact> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/sourceArtifact> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "sourceArtifact" ;
     rdfs:comment "A reference to an artifact containing the sources for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/staticAnalysisReport> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/staticAnalysisReport> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "staticAnalysisReport" ;
     rdfs:comment "A reference to a static analysis report for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/support> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/support> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "support" ;
     rdfs:comment "A reference to the software support channel or other support information for a package."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/vcs> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/vcs> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "vcs" ;
     rdfs:comment "A reference to a version control system related to a software artifact."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/vulnerabilityDisclosureReport> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/vulnerabilityDisclosureReport> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "vulnerabilityDisclosureReport" ;
     rdfs:comment "A reference to a Vulnerability Disclosure Report (VDR) which provides the software supplier's analysis and findings describing the impact (or lack of impact) that reported vulnerabilities have on packages or products in the supplier's SBOM as defined in [NIST SP 800-161 Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations](https://csrc.nist.gov/pubs/sp/800/161/r1/final)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/vulnerabilityExploitabilityAssessment> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/vulnerabilityExploitabilityAssessment> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "vulnerabilityExploitabilityAssessment" ;
     rdfs:comment "A reference to a Vulnerability Exploitability eXchange (VEX) statement which provides information on whether a product is impacted by a specific vulnerability in an included package and, if affected, whether there are actions recommended to remediate. See also [NTIA VEX one-page summary](https://ntia.gov/files/ntia/publications/vex_one-page_summary.pdf)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/x509Cert> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ExternalRefType/x509Cert> a owl:NamedIndividual,
         ns1:ExternalRefType ;
     rdfs:label "x509Cert" ;
-    rdfs:comment "A reference to an X.509 certificate as defined in [RFC 1422](https://datatracker.ietf.org/doc/rfc1422/). The media type shall be one of application/x-x509-ca-cert or application/x-x509-user-cert."@en .
+    rdfs:comment "A reference to an X.509 certificate as defined in [RFC 5280](https://datatracker.ietf.org/doc/rfc5280/). The primary media type shall be `application/pkix-cert`. The legacy media types `application/x-x509-ca-cert` and `application/x-x509-user-cert` may be used for backward compatibility, but shall not be used in new implementations. NOTE — RFC 5280 supersedes earlier X.509 profiles, including RFC 1422. Existing references based on RFC 1422 remain valid."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/assistiveAutomation> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/assistiveAutomation> a owl:NamedIndividual,
         ns1:IsoAutomationLevel ;
     rdfs:label "assistiveAutomation" ;
     rdfs:comment "Level 1 - Assistive automation. The system assists an operator."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/autonomous> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/autonomous> a owl:NamedIndividual,
         ns1:IsoAutomationLevel ;
     rdfs:label "autonomous" ;
     rdfs:comment "Level 6 - Autonomous. The system is capable of modifying its intended domain of use or its goals without external intervention, control or oversight."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/conditionalAutomation> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/conditionalAutomation> a owl:NamedIndividual,
         ns1:IsoAutomationLevel ;
     rdfs:label "conditionalAutomation" ;
     rdfs:comment "Level 3 - Conditional automation. The system can propose strategies and then automatically execute the approved plan, with an external agent being ready to take over when necessary."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/fullAutomation> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/fullAutomation> a owl:NamedIndividual,
         ns1:IsoAutomationLevel ;
     rdfs:label "fullAutomation" ;
     rdfs:comment "Level 5 - Full automation. The system is capable of performing its entire mission without external intervention."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/highAutomation> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/highAutomation> a owl:NamedIndividual,
         ns1:IsoAutomationLevel ;
     rdfs:label "highAutomation" ;
     rdfs:comment "Level 4 - High automation. The system performs parts of its mission without external intervention."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/notAutomated> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/notAutomated> a owl:NamedIndividual,
         ns1:IsoAutomationLevel ;
     rdfs:label "notAutomated" ;
     rdfs:comment "Level 0 - Not automated. No automation. The operator fully controls the system."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/IsoAutomationLevel/partialAutomation> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/IsoAutomationLevel/partialAutomation> a owl:NamedIndividual,
         ns1:IsoAutomationLevel ;
     rdfs:label "partialAutomation" ;
     rdfs:comment "Level 2 - Partial automation or task automation. Some sub-functions of the system are fully automated while the system remain under control of an external agent. The system can perform actions for an approved task without requiring the agent's continuous direct control."@en .
@@ -826,7 +967,7 @@ ns1:LifecycleScopedRelationship a owl:Class,
     rdfs:subClassOf ns1:Relationship ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:class ns1:LifecycleScopeType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/design> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/development> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/build> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/test> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/runtime> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/decommission> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/update> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/other> ) ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/design> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/development> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/build> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/test> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/runtime> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/decommission> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/update> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/other> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:path ns1:scope ] .
@@ -839,17 +980,17 @@ ns1:PackageVerificationCode a owl:Class,
     sh:property [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:path ns1:packageVerificationCodeExcludedFile ],
-        [ sh:class ns1:HashAlgorithm ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/adler32> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/blake2b256> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/blake2b384> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/blake2b512> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/blake3> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/crystalsDilithium> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/crystalsKyber> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/falcon> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/md2> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/md4> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/md5> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/md6> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/other> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha1> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha224> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha256> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha384> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha512> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha3_224> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha3_256> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha3_384> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha3_512> ) ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:algorithm ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:hashValue ] .
+            sh:path ns1:hashValue ],
+        [ sh:class ns1:HashAlgorithm ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/adler32> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/blake2b256> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/blake2b384> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/blake2b512> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/blake3> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/crystalsDilithium> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/crystalsKyber> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/falcon> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/md2> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/md4> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/md5> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/md6> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/other> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha1> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha224> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha256> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha384> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha512> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha3_224> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha3_256> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha3_384> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha3_512> ) ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:algorithm ] .
 
 ns1:Person a owl:Class ;
     rdfs:comment "An individual human being."@en ;
@@ -864,19 +1005,11 @@ ns1:PhysicalLocation a owl:Class,
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:city ],
+            sh:path ns1:postOfficeBoxNumber ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:countyCode ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:postalName ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:provinceStateCode ],
+            sh:path ns1:postalCode ],
         [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:path ns1:geographicPointLocation ],
@@ -888,102 +1021,115 @@ ns1:PhysicalLocation a owl:Class,
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:postOfficeBoxNumber ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
             sh:path ns1:streetAddress ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:postalCode ] .
+            sh:path ns1:postalName ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:provinceStateCode ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:city ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:countyCode ] .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProcessReadinessType/active> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProcessReadinessType/active> a owl:NamedIndividual,
         ns1:ProcessReadinessType ;
     rdfs:label "active" ;
-    rdfs:comment "in use"@en .
+    rdfs:comment "In use."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProcessReadinessType/draft> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProcessReadinessType/draft> a owl:NamedIndividual,
         ns1:ProcessReadinessType ;
     rdfs:label "draft" ;
-    rdfs:comment "in production"@en .
+    rdfs:comment "Not yet finalized; under development or review."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProcessReadinessType/obsolete> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProcessReadinessType/obsoleted> a owl:NamedIndividual,
         ns1:ProcessReadinessType ;
-    rdfs:label "obsolete" ;
-    rdfs:comment "superseded or not valid at present"@en .
+    rdfs:label "obsoleted" ;
+    rdfs:comment "Superseded or not valid at present."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProcessReadinessType/other> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProcessReadinessType/other> a owl:NamedIndividual,
         ns1:ProcessReadinessType ;
     rdfs:label "other" ;
-    rdfs:comment "other"@en .
+    rdfs:comment "Other."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/ai> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/ai> a owl:NamedIndividual,
         ns1:ProfileIdentifierType ;
     rdfs:label "ai" ;
     rdfs:comment "The element follows the AI profile specification."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/operations> a owl:NamedIndividual,
-        ns1:ProfileIdentifierType ;
-    rdfs:label "ai" ;
-    rdfs:comment "The element follows the Operations profile specification."@en .
-
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/functionalSafety> a owl:NamedIndividual,
-        ns1:ProfileIdentifierType ;
-    rdfs:label "functionalSafety" ;
-    rdfs:comment "The element follows the Functional Safety profile specification."@en .
-
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/build> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/build> a owl:NamedIndividual,
         ns1:ProfileIdentifierType ;
     rdfs:label "build" ;
     rdfs:comment "The element follows the Build profile specification."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/core> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/core> a owl:NamedIndividual,
         ns1:ProfileIdentifierType ;
     rdfs:label "core" ;
     rdfs:comment "The element follows the Core profile specification."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/dataset> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/dataset> a owl:NamedIndividual,
         ns1:ProfileIdentifierType ;
     rdfs:label "dataset" ;
     rdfs:comment "The element follows the Dataset profile specification."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/expandedLicensing> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/expandedLicensing> a owl:NamedIndividual,
         ns1:ProfileIdentifierType ;
     rdfs:label "expandedLicensing" ;
     rdfs:comment "The element follows the ExpandedLicensing profile specification."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/extension> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/extension> a owl:NamedIndividual,
         ns1:ProfileIdentifierType ;
     rdfs:label "extension" ;
     rdfs:comment "The element follows the Extension profile specification."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/hardware> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/functionalSafety> a owl:NamedIndividual,
+        ns1:ProfileIdentifierType ;
+    rdfs:label "functionalSafety" ;
+    rdfs:comment "The element follows the FunctionalSafety profile specification."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/hardware> a owl:NamedIndividual,
         ns1:ProfileIdentifierType ;
     rdfs:label "hardware" ;
     rdfs:comment "The element follows the Hardware profile specification."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/lite> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/lite> a owl:NamedIndividual,
         ns1:ProfileIdentifierType ;
     rdfs:label "lite" ;
     rdfs:comment "The element follows the Lite profile specification."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/security> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/operations> a owl:NamedIndividual,
+        ns1:ProfileIdentifierType ;
+    rdfs:label "operations" ;
+    rdfs:comment "The element follows the Operations profile specification."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/security> a owl:NamedIndividual,
         ns1:ProfileIdentifierType ;
     rdfs:label "security" ;
     rdfs:comment "The element follows the Security profile specification."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/simpleLicensing> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/service> a owl:NamedIndividual,
+        ns1:ProfileIdentifierType ;
+    rdfs:label "service" ;
+    rdfs:comment "The element follows the Service profile specification."@en .
+
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/simpleLicensing> a owl:NamedIndividual,
         ns1:ProfileIdentifierType ;
     rdfs:label "simpleLicensing" ;
     rdfs:comment "The element follows the SimpleLicensing profile specification."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/software> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/software> a owl:NamedIndividual,
         ns1:ProfileIdentifierType ;
     rdfs:label "software" ;
     rdfs:comment "The element follows the Software profile specification."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/supplyChain> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/supplyChain> a owl:NamedIndividual,
         ns1:ProfileIdentifierType ;
     rdfs:label "supplyChain" ;
     rdfs:comment "The element follows the SupplyChain profile specification."@en .
@@ -993,422 +1139,448 @@ ns1:Regulation a owl:Class ;
     rdfs:subClassOf ns1:Specification ;
     sh:nodeKind sh:IRI .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipCompleteness/complete> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipCompleteness/complete> a owl:NamedIndividual,
         ns1:RelationshipCompleteness ;
     rdfs:label "complete" ;
     rdfs:comment "The relationship is known to be exhaustive."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipCompleteness/incomplete> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipCompleteness/incomplete> a owl:NamedIndividual,
         ns1:RelationshipCompleteness ;
     rdfs:label "incomplete" ;
     rdfs:comment "The relationship is known not to be exhaustive."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipCompleteness/noAssertion> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipCompleteness/noAssertion> a owl:NamedIndividual,
         ns1:RelationshipCompleteness ;
     rdfs:label "noAssertion" ;
     rdfs:comment "No assertion can be made about the completeness of the relationship."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/affects> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/affects> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "affects" ;
-    rdfs:comment "The `from` Vulnerability, Action or DefinedProcess affects each `to` Element."@en .
+    rdfs:comment "The `from` /Security/Vulnerability, Action or DefinedProcess affects each `to` Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/amendedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/amendedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "amendedBy" ;
     rdfs:comment "The `from` Element is amended by each `to` Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/ancestorOf> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/ancestorOf> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "ancestorOf" ;
     rdfs:comment "The `from` Element is an ancestor of each `to` Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/availableFrom> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/assumes> a owl:NamedIndividual,
+        ns1:RelationshipType ;
+    rdfs:label "assumes" ;
+    rdfs:comment "The `from` Element assumes each `to` /FunctionalSafety/Assumption."@en .
+
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/availableFrom> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "availableFrom" ;
     rdfs:comment "The `from` Element is available from the additional supplier described by each `to` Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/configures> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/configures> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "configures" ;
     rdfs:comment "The `from` Element is a configuration applied to each `to` Element, during a LifecycleScopeType period."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/conformsTo> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/conformsTo> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "conformsTo" ;
-    rdfs:comment "The `from` Element conforms to each `to` Specification."@en .
+    rdfs:comment "The `from` Element conforms to each `to` /FunctionalSafety/Assumption or Specification."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/contains> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/contains> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "contains" ;
     rdfs:comment "The `from` Element contains each `to` Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/coordinatedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/coordinatedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "coordinatedBy" ;
-    rdfs:comment "The `from` Vulnerability is coordinatedBy the `to` Agent(s) (vendor, researcher, or consumer agent)."@en .
+    rdfs:comment "The `from` /Security/Vulnerability is coordinatedBy the `to` Agent(s) (vendor, researcher, or consumer agent)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/copiedTo> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/copiedTo> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "copiedTo" ;
     rdfs:comment "The `from` Element has been copied to each `to` Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/createdBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/createdBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "createdBy" ;
-    rdfs:comment "The `from` Element's Action or DefinedProcess is createdBy `to` Agent(s)."@en .
+    rdfs:comment "The `from` Action or DefinedProcess is createdBy `to` Agent(s)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/delegatedTo> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/delegatedTo> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "delegatedTo" ;
-    rdfs:comment "The `from` Agent is delegating an action to the Agent of the `to` Relationship (which shall be of type invokedBy), during a LifecycleScopeType (e.g. the `to` invokedBy Relationship is being done on behalf of `from`)."@en .
+    rdfs:comment "The `from` Agent is delegating an action to the Agent of the `to` Relationship (which shall be of type invokedBy), during a LifecycleScopeType period (e.g. the `to` invokedBy Relationship is being done on behalf of `from`)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/dependsOn> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/dependsOn> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "dependsOn" ;
     rdfs:comment "The `from` Element depends on each `to` Element, during a LifecycleScopeType period."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/descendantOf> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/descendantOf> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "descendantOf" ;
     rdfs:comment "The `from` Element is a descendant of each `to` Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/describes> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/describes> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "describes" ;
     rdfs:comment "The `from` Element describes each `to` Element. To denote the root(s) of a tree of elements in a collection, the rootElement property shall be used."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/doesNotAffect> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/doesNotAffect> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "doesNotAffect" ;
-    rdfs:comment "The `from` Vulnerability has no impact on each `to` Element. The use of the `doesNotAffect` is constrained to `VexNotAffectedVulnAssessmentRelationship` classed relationships."@en .
+    rdfs:comment "The `from` /Security/Vulnerability has no impact on each `to` Element. The use of the `doesNotAffect` is constrained to `/Security/VexNotAffectedVulnAssessmentRelationship` classed relationships."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/evaluatedOn> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/evaluatedOn> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "evaluatedOn" ;
     rdfs:comment "The `from` Element has been evaluated on the `to` Element(s)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/expandsTo> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/expandsTo> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "expandsTo" ;
     rdfs:comment "The `from` Element expands out as an artifact described by each `to` Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/exploitCreatedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/exploitCreatedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "exploitCreatedBy" ;
-    rdfs:comment "The `from` Vulnerability has had an exploit created against it by each `to` Agent."@en .
+    rdfs:comment "The `from` /Security/Vulnerability has had an exploit created against it by each `to` Agent."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/finetunedOn> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/finetunedOn> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "finetunedOn" ;
     rdfs:comment "The `from` Element has been finetuned on the `to` Element(s)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/fixedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/fixedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "fixedBy" ;
-    rdfs:comment "Designates a `from` Vulnerability has been fixed by the `to` Agent(s)."@en .
+    rdfs:comment "Designates a `from` /Security/Vulnerability has been fixed by the `to` Agent(s)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/fixedIn> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/fixedIn> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "fixedIn" ;
-    rdfs:comment "A `from` Vulnerability has been fixed in each `to` Element. The use of the `fixedIn` type is constrained to `VexFixedVulnAssessmentRelationship` classed relationships."@en .
+    rdfs:comment "A `from` /Security/Vulnerability has been fixed in each `to` Element. The use of the `fixedIn` type is constrained to `/Security/VexFixedVulnAssessmentRelationship` classed relationships."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/follows> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/follows> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "follows" ;
     rdfs:comment "The `to` Element succeeds the `from` Element, establishing a unidirectional sequence. This succession is defined as chronological, procedural, or logical. It is used to represent either a temporal order (e.g., in a workflow) or a logical order for processing and traversal (e.g., in an ordered list)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/foundBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/foundBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "foundBy" ;
-    rdfs:comment "Designates a `from` Vulnerability was originally discovered by the `to` Agent(s)."@en .
+    rdfs:comment "Designates a `from` /Security/Vulnerability was originally discovered by the `to` Agent(s)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/generates> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/generates> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "generates" ;
     rdfs:comment "The `from` Element generates each `to` Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasAddedFile> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasAddedFile> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasAddedFile" ;
     rdfs:comment "Every `to` Element is a file added to the `from` Element (`from` hasAddedFile `to`)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasAssessmentFor> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasAssessmentFor> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasAssessmentFor" ;
-    rdfs:comment "Relates a `from` Vulnerability and each `to` Element with a security assessment. To be used with `VulnAssessmentRelationship` types."@en .
+    rdfs:comment "Relates a `from` /Security/Vulnerability and each `to` Element with a security assessment. The use of the `hasAssessmentFor` type is constrained to `/Security/VulnAssessmentRelationship` classed relationships."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasAssociatedVulnerability> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasAssociatedVulnerability> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasAssociatedVulnerability" ;
-    rdfs:comment "Used to associate a `from` Artifact with each `to` Vulnerability."@en .
+    rdfs:comment "Used to associate a `from` Artifact with each `to` /Security/Vulnerability."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasConcludedLicense> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasConcludedLicense> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasConcludedLicense" ;
-    rdfs:comment "The `from` SoftwareArtifact is concluded by the SPDX data creator to be governed by each `to` AnyLicenseInfo."@en .
+    rdfs:comment "The `from` Artifact is concluded by the SPDX data creator to be governed by each `to` /SimpleLicensing/AnyLicenseInfo. If the `to` of an Artifact's `hasConcludedLicense` is not the same as the `to` of its `hasDeclaredLicense`, a written explanation should be provided in the comment field of the `hasConcludedLicense` relationship."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasContactPoint> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasContactPoint> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasContactPoint" ;
-    rdfs:comment "The `from` Artifact has each `to` Agent as a contact point. The use of `hasContactPoint` type is constrained to `ContactPointRelationship` typed relationships. The type of contact (i.e. security) may be specified using a `ContactPointRelationship` element."@en .
+    rdfs:comment "The `from` Artifact has each `to` Agent as a contact point. The use of the `hasContactPoint` type is constrained to `ContactPointRelationship` classed relationships. The type of contact (i.e. security) may be specified using a `ContactPointRelationship` element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDataFile> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDataFile> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasDataFile" ;
     rdfs:comment "The `from` Element treats each `to` Element as a data file. A data file is an artifact that stores data required or optional for the `from` Element's functionality. A data file can be a database file, an index file, a log file, an AI model file, a calibration data file, a temporary file, a backup file, and more. For AI training dataset, test dataset, test artifact, configuration data, build input data, and build output data, please consider using the more specific relationship types: `trainedOn`, `testedOn`, `hasTest`, `configures`, `hasInput`, and `hasOutput`, respectively. This relationship does not imply dependency."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDeclaredLicense> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDeclaredLicense> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasDeclaredLicense" ;
-    rdfs:comment "The `from` SoftwareArtifact was discovered to actually contain each `to` AnyLicenseInfo (for example, as detected by automated tooling)."@en .
+    rdfs:comment "The `from` Artifact was discovered to actually contain each `to` /SimpleLicensing/AnyLicenseInfo (for example, as detected by automated tooling)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDeletedFile> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDeletedFile> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasDeletedFile" ;
     rdfs:comment "Every `to` Element is a file deleted from the `from` Element (`from` hasDeletedFile `to`)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDependencyManifest> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDependencyManifest> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasDependencyManifest" ;
     rdfs:comment "The `from` Element has manifest files that contain dependency information in each `to` Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDistributionArtifact> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDistributionArtifact> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasDistributionArtifact" ;
     rdfs:comment "The `from` Element is distributed as an artifact in each `to` Element (e.g. an RPM or archive file)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDocumentation> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDocumentation> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasDocumentation" ;
     rdfs:comment "The `from` Element is documented by each `to` Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDynamicLink> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDynamicLink> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasDynamicLink" ;
     rdfs:comment "The `from` Element dynamically links in each `to` Element, during a LifecycleScopeType period."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasEvidence> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasEvidence> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasEvidence" ;
     rdfs:comment "Every `to` Element is considered as evidence for the `from` Element (`from` hasEvidence `to`)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasExample> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasExample> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasExample" ;
     rdfs:comment "Every `to` Element is an example for the `from` Element (`from` hasExample `to`)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasHost> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasHost> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasHost" ;
-    rdfs:comment "The `from` Build was run on the `to` Element during a LifecycleScopeType period (e.g. the host that the build runs on)."@en .
+    rdfs:comment "The `from` /Build/Build was run on the `to` Element during a LifecycleScopeType period (e.g. the host that the build runs on)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasInput> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasInput> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasInput" ;
-    rdfs:comment "The `from` Build, DefinedProcess or Action element has each `to` Element as an input."@en .
+    rdfs:comment "The `from` /Build/Build, DefinedProcess or Action element has each `to` Element as an input."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasMetadata> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasMetadata> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasMetadata" ;
     rdfs:comment "Every `to` Element is metadata about the `from` Element (`from` hasMetadata `to`)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasOptionalComponent> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasOptionalComponent> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasOptionalComponent" ;
     rdfs:comment "Every `to` Element is an optional component of the `from` Element (`from` hasOptionalComponent `to`)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasOptionalDependency> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasOptionalDependency> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasOptionalDependency" ;
     rdfs:comment "The `from` Element optionally depends on each `to` Element, during a LifecycleScopeType period."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasOutput> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasOutput> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasOutput" ;
-    rdfs:comment "The `from` Build, DefinedProcess or Action element generates each `to` Element as an output."@en .
+    rdfs:comment "The `from` /Build/Build, DefinedProcess or Action element generates each `to` Element as an output."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasPrerequisite> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasPrerequisite> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasPrerequisite" ;
     rdfs:comment "The `from` Element has a prerequisite on each `to` Element, during a LifecycleScopeType period."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasProvidedDependency> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasProvidedDependency> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasProvidedDependency" ;
     rdfs:comment "The `from` Element has a dependency on each `to` Element, dependency is not in the distributed artifact, but assumed to be provided, during a LifecycleScopeType period."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasRequirement> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasRequirement> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasRequirement" ;
     rdfs:comment "The `from` Element has a requirement on each `to` Element, during a LifecycleScopeType period."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasResolution> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasResolution> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasResolution" ;
-    rdfs:comment "The `from` ResolutionAction point to the `to` OutOfSpecAction that is addressed."@en .
+    rdfs:comment "The `from` /SupplyChain/ResolutionAction points to the `to` /SupplyChain/OutOfSpecAction that is addressed."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasSpecification> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasRoleIn> a owl:NamedIndividual,
+        ns1:RelationshipType ;
+    rdfs:label "hasRoleIn" ;
+    rdfs:comment "The `from` Element has a role in the `to` Element. The use of the hasRoleIn is constrained to `RoleRelationship` classed relationships."@en .
+
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasSpecification> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasSpecification" ;
     rdfs:comment "Every `to` Element is a specification for the `from` Element (`from` hasSpecification `to`), during a LifecycleScopeType period."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasStaticLink> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasStaticLink> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasStaticLink" ;
     rdfs:comment "The `from` Element statically links in each `to` Element, during a LifecycleScopeType period."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasTest> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasTest> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasTest" ;
     rdfs:comment "Every `to` Element is a test artifact for the `from` Element (`from` hasTest `to`), during a LifecycleScopeType period."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasTestCase> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasTestCase> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasTestCase" ;
     rdfs:comment "Every `to` Element is a test case for the `from` Element (`from` hasTestCase `to`)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasVariant> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/hasVariant> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "hasVariant" ;
     rdfs:comment "Every `to` Element is a variant the `from` Element (`from` hasVariant `to`)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/implementedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/implementedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "implementedBy" ;
     rdfs:comment "The `from` Requirement is implemented in the `to` Element(s)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/invokedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/invokedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "invokedBy" ;
-    rdfs:comment "The `from` Element was invoked by the `to` Agent, during a LifecycleScopeType period (for example, a Build element that describes a build step)."@en .
+    rdfs:comment "The `from` Element was invoked by the `to` Agent, during a LifecycleScopeType period (for example, a /Build/Build element that describes a build step)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/locatedAt> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/locatedAt> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "locatedAt" ;
-    rdfs:comment "`from` element located at a specific `to` location. A time period is optional."@en .
+    rdfs:comment "`from` Element located at a specific `to` Location. A time period is optional."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/modifiedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/modifiedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "modifiedBy" ;
     rdfs:comment "The `from` Element is modified by each `to` Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/other> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/other> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "other" ;
     rdfs:comment "Every `to` Element is related to the `from` Element where the relationship type is not described by any of the SPDX relationship types (this relationship is directionless)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/packagedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/packagedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "packagedBy" ;
     rdfs:comment "Every `to` Element is a packaged instance of the `from` Element (`from` packagedBy `to`)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/patchedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/patchedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "patchedBy" ;
     rdfs:comment "Every `to` Element is a patch for the `from` Element (`from` patchedBy `to`)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/performedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/performedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "performedBy" ;
-    rdfs:comment "Every `from` action is performedBy `to` Agent."@en .
+    rdfs:comment "Every `from` Action is performedBy `to` Agent."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/pretrainedOn> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/pretrainedOn> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "pretrainedOn" ;
     rdfs:comment "The `from` Element has been pretrained on the `to` Element(s)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/providesSupportFor> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/providesSupportFor> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "providesSupportFor" ;
-    rdfs:comment "The `from` Agent provides support for each `to` Artifact. Shall be a `SupportRelationship` type."@en .
+    rdfs:comment "The `from` Agent provides support for each `to` Artifact. The use of the `providesSupportFor` type is constrained to `SupportRelationship` classed relationships."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/publishedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/publishedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "publishedBy" ;
-    rdfs:comment "Designates a `from` Vulnerability was made available for public use or reference by each `to` Agent."@en .
+    rdfs:comment "Designates a `from` /Security/Vulnerability was made available for public use or reference by each `to` Agent."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/reportedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/reportedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "reportedBy" ;
-    rdfs:comment "Designates a `from` Vulnerability was first reported to a project, vendor, or tracking database for formal identification by each `to` Agent."@en .
+    rdfs:comment "Designates a `from` /Security/Vulnerability was first reported to a project, vendor, or tracking database for formal identification by each `to` Agent."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/republishedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/republishedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "republishedBy" ;
-    rdfs:comment "Designates a `from` Vulnerability's details were tracked, aggregated, and/or enriched to improve context (i.e. NVD) by each `to` Agent."@en .
+    rdfs:comment "Designates a `from` /Security/Vulnerability's details were tracked, aggregated, and/or enriched to improve context (i.e. NVD) by each `to` Agent."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/resolved> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/resolved> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "resolved" ;
-    rdfs:comment "The `to` OutOfSpecAction is resolved in the `from` ResolutionAction."@en .
+    rdfs:comment "The `to` /SupplyChain/OutOfSpecAction is resolved in the `from` /SupplyChain/ResolutionAction."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/runsOn> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/runsOn> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "runsOn" ;
-    rdfs:comment "The `from` Element (the instructions) of runs on each `to` Hardware (processing element), during a LifecycleScopeType period."@en .
+    rdfs:comment "The `from` Element (the instructions) runs on each `to` /Hardware/Hardware (processing element), during a LifecycleScopeType period."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/serializedInArtifact> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/serializedInArtifact> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "serializedInArtifact" ;
     rdfs:comment "The `from` SpdxDocument can be found in a serialized form in each `to` Artifact."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/testedOn> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/testedOn> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "testedOn" ;
     rdfs:comment "The `from` Element has been tested on the `to` Element(s)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/tracedToDetail> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/tracedToDetail> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "tracedToDetail" ;
-    rdfs:comment "the `from` Requirement is refined and further elaborated by each `to` Requirement, which contains more detailed implementation information."@en .
+    rdfs:comment "The `from` Requirement is refined and further elaborated by each `to` Requirement, which contains more detailed implementation information."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/trainedOn> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/trainedOn> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "trainedOn" ;
     rdfs:comment "The `from` Element has been trained on the `to` Element(s)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/underInvestigationFor> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/underInvestigationFor> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "underInvestigationFor" ;
-    rdfs:comment "The `from` Vulnerability impact is being investigated for each `to` Element. The use of the `underInvestigationFor` type is constrained to `VexUnderInvestigationVulnAssessmentRelationship` classed relationships."@en .
+    rdfs:comment "The `from` /Security/Vulnerability impact is being investigated for each `to` Element. The use of the `underInvestigationFor` type is constrained to `/Security/VexUnderInvestigationVulnAssessmentRelationship` classed relationships."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/usesTool> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/usesTool> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "usesTool" ;
     rdfs:comment "The `from` Element uses each `to` Element as a tool, during a LifecycleScopeType period."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/validatedOn> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/validatedOn> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "validatedOn" ;
     rdfs:comment "The `from` Element has been validated on the `to` Element(s)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/RelationshipType/verifiedBy> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/RelationshipType/verifiedBy> a owl:NamedIndividual,
         ns1:RelationshipType ;
     rdfs:label "verifiedBy" ;
-    rdfs:comment "The `from` Requirement that has verification (test, review, analysis etc.) details defined in the `to` RequirementVerification."@en .
+    rdfs:comment "The `from` Requirement that has verification (test, review, analysis etc.) details defined in the `to` /FunctionalSafety/RequirementVerification."@en .
 
-ns1:Requirement a owl:Class,
+<https://spdx.org/rdf/3/terms/Core/RequirementStatusType/active> a owl:NamedIndividual,
+        ns1:RequirementStatusType ;
+    rdfs:label "active" ;
+    rdfs:comment "A requirement has been approved by stakeholder, and can be include in traceability."@en .
+
+<https://spdx.org/rdf/3/terms/Core/RequirementStatusType/backlog> a owl:NamedIndividual,
+        ns1:RequirementStatusType ;
+    rdfs:label "backlog" ;
+    rdfs:comment "A requirement has been captured and logged, but not yet ready to become a formal requirement draft. A backlog requirement may still be incomplete or ambiguous."@en .
+
+<https://spdx.org/rdf/3/terms/Core/RequirementStatusType/draft> a owl:NamedIndividual,
+        ns1:RequirementStatusType ;
+    rdfs:label "draft" ;
+    rdfs:comment "A requirement is considered a draft state and may be modified before being submitted for review."@en .
+
+<https://spdx.org/rdf/3/terms/Core/RequirementStatusType/retired> a owl:NamedIndividual,
+        ns1:RequirementStatusType ;
+    rdfs:label "retired" ;
+    rdfs:comment "A requirement is no longer active for a specific use."@en .
+
+<https://spdx.org/rdf/3/terms/Core/RequirementStatusType/reviewable> a owl:NamedIndividual,
+        ns1:RequirementStatusType ;
+    rdfs:label "reviewable" ;
+    rdfs:comment "A requirement is ready for formal review by stakeholders for a specific use."@en .
+
+ns1:RoleRelationship a owl:Class,
         sh:NodeShape ;
-    rdfs:comment "A distinct unit representing a requirement, as used in systems, software, and hardware engineering."@en ;
-    rdfs:subClassOf ns1:Element ;
+    rdfs:comment "RoleRelationship represents a relationship between an entity holding a role and the scope or context in which that role applies. The givenRole property specifies the role assigned."@en ;
+    rdfs:subClassOf ns1:Relationship ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
+    sh:property [ sh:class ns1:Role ;
             sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:requirementStatement ],
-        [ sh:class ns1:LifecycleScopeType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/design> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/development> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/build> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/test> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/runtime> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/decommission> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/update> <https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/other> ) ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:devLifecycleStage ],
-        [ sh:class ns1:ExternalIdentifier ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:requirementUUID ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:requirementRationale ] .
+            sh:path ns1:givenRole ],
+        [ sh:class ns1:Agent ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:assignedBy ] .
 
 ns1:SoftwareAgent a owl:Class ;
     rdfs:comment "A software agent."@en ;
@@ -1420,33 +1592,33 @@ ns1:SpdxDocument a owl:Class,
     rdfs:comment "A collection of SPDX Elements that could potentially be serialized."@en ;
     rdfs:subClassOf ns1:ElementCollection ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class <https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo> ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:dataLicense ],
+    sh:property [ sh:class ns1:ExternalMap ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns1:import ],
         [ sh:class ns1:NamespaceMap ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:path ns1:namespaceMap ],
-        [ sh:class ns1:ExternalMap ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:import ] .
+        [ sh:class <https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo> ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:dataLicense ] .
 
-<https://spdx.org/rdf/3.1/terms/Core/SpecificationType/formalStandard> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/SpecificationType/formalStandard> a owl:NamedIndividual,
         ns1:SpecificationType ;
     rdfs:label "formalStandard" ;
     rdfs:comment "A formal standard is a standard ratified by a recognized standards-development organization and published as a normative reference."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/SpecificationType/other> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/SpecificationType/other> a owl:NamedIndividual,
         ns1:SpecificationType ;
     rdfs:label "other" ;
     rdfs:comment "Any specification that does not fall under any of the other entries."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/SpecificationType/regulation> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/SpecificationType/regulation> a owl:NamedIndividual,
         ns1:SpecificationType ;
     rdfs:label "regulation" ;
     rdfs:comment "A mandatory legal specification issued by a governmental or regulatory authority. Compliance is enforceable by law."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/SpecificationType/specification> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/SpecificationType/specification> a owl:NamedIndividual,
         ns1:SpecificationType ;
     rdfs:label "specification" ;
     rdfs:comment "A specification is a detailed document (or set of documents) that describes the requirements, design, behavior, or other characteristics of a system, component, or process so that all stakeholders have a clear, unambiguous reference."@en .
@@ -1457,23 +1629,15 @@ ns1:SupportRelationship a owl:Class,
     rdfs:subClassOf ns1:Relationship ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:class ns1:SupportType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/SupportType/development> <https://spdx.org/rdf/3.1/terms/Core/SupportType/support> <https://spdx.org/rdf/3.1/terms/Core/SupportType/deployed> <https://spdx.org/rdf/3.1/terms/Core/SupportType/limitedSupport> <https://spdx.org/rdf/3.1/terms/Core/SupportType/endOfSupport> <https://spdx.org/rdf/3.1/terms/Core/SupportType/noSupport> <https://spdx.org/rdf/3.1/terms/Core/SupportType/noAssertion> ) ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/SupportType/development> <https://spdx.org/rdf/3/terms/Core/SupportType/support> <https://spdx.org/rdf/3/terms/Core/SupportType/deployed> <https://spdx.org/rdf/3/terms/Core/SupportType/limitedSupport> <https://spdx.org/rdf/3/terms/Core/SupportType/endOfSupport> <https://spdx.org/rdf/3/terms/Core/SupportType/noSupport> <https://spdx.org/rdf/3/terms/Core/SupportType/noAssertion> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:path ns1:supportLevel ] .
 
-ns1:actionEndTime a owl:DatatypeProperty ;
-    rdfs:comment "Property that describes the time at which an action stops."@en ;
-    rdfs:range xsd:dateTimeStamp .
-
 ns1:actionLocation a owl:ObjectProperty ;
     rdfs:comment "Location of a specific action."@en ;
     rdfs:range ns1:Location .
-
-ns1:actionStartTime a owl:DatatypeProperty ;
-    rdfs:comment "Property describing the start time of an action."@en ;
-    rdfs:range xsd:dateTimeStamp .
 
 ns1:additionalInformation a owl:ObjectProperty ;
     rdfs:comment "Additional relevance information."@en ;
@@ -1482,6 +1646,14 @@ ns1:additionalInformation a owl:ObjectProperty ;
 ns1:annotationType a owl:ObjectProperty ;
     rdfs:comment "Describes the type of annotation."@en ;
     rdfs:range ns1:AnnotationType .
+
+ns1:assignedBy a owl:ObjectProperty ;
+    rdfs:comment "assignedBy identifies the agent that grants or assigns the role to the target element."@en ;
+    rdfs:range ns1:Agent .
+
+ns1:authorization a owl:DatatypeProperty ;
+    rdfs:comment "Authorization specifies the permissions, rights, privileges, or benefits granted to a Role, defining what the role is authorized to access, perform, or receive."@en ;
+    rdfs:range xsd:string .
 
 ns1:beginIntegerRange a owl:DatatypeProperty ;
     rdfs:comment "Defines the beginning of a range."@en ;
@@ -1535,7 +1707,7 @@ ns1:creationInfo a owl:ObjectProperty ;
 ns1:dataLicense a owl:ObjectProperty ;
     rdfs:comment """Provides the license under which the SPDX documentation of the Element can be
 used."""@en ;
-    rdfs:range <https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo> .
+    rdfs:range <https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo> .
 
 ns1:definingArtifact a owl:ObjectProperty ;
     rdfs:comment """Artifact representing a serialization instance of SPDX data containing the
@@ -1566,10 +1738,6 @@ ns1:endIntegerRange a owl:DatatypeProperty ;
     rdfs:comment "Defines the end of a range."@en ;
     rdfs:range xsd:positiveInteger .
 
-ns1:endTime a owl:DatatypeProperty ;
-    rdfs:comment "Specifies the time from which an element is no longer applicable / valid."@en ;
-    rdfs:range xsd:dateTimeStamp .
-
 ns1:externalIdentifier a owl:ObjectProperty ;
     rdfs:comment """Provides a reference to a resource outside the scope of SPDX 3 content
 that uniquely identifies an Element."""@en ;
@@ -1598,11 +1766,15 @@ ns1:from a owl:ObjectProperty ;
     rdfs:range ns1:Element .
 
 ns1:geographicPointLocation a owl:DatatypeProperty ;
-    rdfs:comment "This is a set of point coordinates as defined in by the GPS standard."@en ;
+    rdfs:comment "A set of geographic point location coordinates."@en ;
     rdfs:range xsd:string .
 
+ns1:givenRole a owl:ObjectProperty ;
+    rdfs:comment "givenRole is a property that specifies the role being assigned in a RoleRelationship. It links the relationship to an instance of the Role class, defining the function, responsibility, or position that the source element confers upon the target element."@en ;
+    rdfs:range ns1:Role .
+
 ns1:headquartersLocation a owl:ObjectProperty ;
-    rdfs:comment "The headquartersLocation defines the location of the organization's headquarters."@en ;
+    rdfs:comment "A location of the organization's headquarters."@en ;
     rdfs:range ns1:Location .
 
 ns1:identifier a owl:DatatypeProperty ;
@@ -1622,7 +1794,8 @@ ns1:inLanguage a owl:DatatypeProperty ;
     rdfs:range xsd:string .
 
 ns1:intendedUse a owl:DatatypeProperty ;
-    rdfs:comment "The intendedUse property is designed to capture a summary of how or for what item or artifact is meant to be used for."@en ;
+    rdfs:comment """A statement of how, or for what purpose, an item or artifact is intended
+to be used."""@en ;
     rdfs:range xsd:string .
 
 ns1:isoAutomationLevel a owl:ObjectProperty ;
@@ -1683,17 +1856,9 @@ ns1:prefix a owl:DatatypeProperty ;
     rdfs:comment "A substitute for a URI."@en ;
     rdfs:range xsd:string .
 
-ns1:processRationale a owl:DatatypeProperty ;
-    rdfs:comment "The reason a process exists."@en ;
-    rdfs:range xsd:string .
-
 ns1:processReadiness a owl:DatatypeProperty ;
-    rdfs:comment "processReadiness describes the readiness of a process."@en ;
+    rdfs:comment "The readiness of a process."@en ;
     rdfs:range ns1:ProcessReadinessType .
-
-ns1:processVersion a owl:DatatypeProperty ;
-    rdfs:comment "Defines the version of a specific process."@en ;
-    rdfs:range xsd:string .
 
 ns1:profileConformance a owl:ObjectProperty ;
     rdfs:comment """Describes one a profile which the creator of this ElementCollection intends to
@@ -1708,6 +1873,10 @@ ns1:quantity a owl:DatatypeProperty ;
     rdfs:comment "Quantity is the amount in the selected QUDT unit."@en ;
     rdfs:range xsd:string .
 
+ns1:referenceSpecification a owl:ObjectProperty ;
+    rdfs:comment "referenceSpecification provides a reference to a DefinedType that defines the specific meaning, structure, and semantics of a Role. It connects the role to its authoritative source definition, ensuring consistent interpretation across different contexts."@en ;
+    rdfs:range ns1:DefinedType .
+
 ns1:relationshipType a owl:ObjectProperty ;
     rdfs:comment "Information about the relationship between two Elements."@en ;
     rdfs:range ns1:RelationshipType .
@@ -1716,17 +1885,25 @@ ns1:releaseTime a owl:DatatypeProperty ;
     rdfs:comment "Specifies the time an artifact was released."@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns1:requirementRationale a owl:DatatypeProperty ;
-    rdfs:comment "Text used to define the rationale or additional information."@en ;
-    rdfs:range xsd:string .
-
 ns1:requirementStatement a owl:DatatypeProperty ;
-    rdfs:comment "A text describing the actual need defined by the requirement."@en ;
+    rdfs:comment "A textual expression describing the actual need defined by the requirement."@en ;
     rdfs:range xsd:string .
 
-ns1:requirementUUID a owl:DatatypeProperty ;
-    rdfs:comment "Provides a universally unique Requirement ID."@en ;
+ns1:requirementStatus a owl:DatatypeProperty ;
+    rdfs:comment "The assessment of the state of a requirement."@en ;
+    rdfs:range ns1:RequirementStatusType .
+
+ns1:requirementUID a owl:DatatypeProperty ;
+    rdfs:comment "A requirementUID is a unique identifier assigned to a Requirement."@en ;
     rdfs:range ns1:ExternalIdentifier .
+
+ns1:responsibility a owl:ObjectProperty ;
+    rdfs:comment "Describes the specific responsibility of a Role."@en ;
+    rdfs:range ns1:Requirement .
+
+ns1:roleQualification a owl:ObjectProperty ;
+    rdfs:comment "roleQualification specifies the requirements, criteria, or conditions that must be met for an entity to be considered qualified to fulfill a particular role."@en ;
+    rdfs:range ns1:Requirement .
 
 ns1:rootElement a owl:ObjectProperty ;
     rdfs:comment "This property is used to denote the root Element(s) of a tree of elements contained in a BOM."@en ;
@@ -1748,10 +1925,6 @@ interpret an Element."""@en ;
 ns1:standardName a owl:DatatypeProperty ;
     rdfs:comment "The name of a relevant standard that may apply to an artifact."@en ;
     rdfs:range xsd:string .
-
-ns1:startTime a owl:DatatypeProperty ;
-    rdfs:comment "Specifies the time from which an element is applicable / valid."@en ;
-    rdfs:range xsd:dateTimeStamp .
 
 ns1:statement a owl:DatatypeProperty ;
     rdfs:comment "Commentary on an assertion that an annotator has made."@en ;
@@ -1778,7 +1951,8 @@ ns1:typeFromSource a owl:DatatypeProperty ;
     rdfs:range xsd:string .
 
 ns1:unitQUDT a owl:DatatypeProperty ;
-    rdfs:comment "QUDT unit is used for measurement criteria based on product type, region and use."@en ;
+    rdfs:comment """A QUDT unit applied to measurement criteria based on product type, region,
+and use."""@en ;
     rdfs:range xsd:string .
 
 ns1:validUntilTime a owl:DatatypeProperty ;
@@ -1790,208 +1964,208 @@ ns1:value a owl:DatatypeProperty ;
     rdfs:comment "A value used in a generic key-value pair."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/ConfidentialityLevelType/amber> a owl:NamedIndividual,
-        ns3:ConfidentialityLevelType ;
+<https://spdx.org/rdf/3/terms/Dataset/ConfidentialityLevelType/amber> a owl:NamedIndividual,
+        ns6:ConfidentialityLevelType ;
     rdfs:label "amber" ;
     rdfs:comment "Data points in the dataset can be shared only with specific organizations and their clients on a need to know basis."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/ConfidentialityLevelType/clear> a owl:NamedIndividual,
-        ns3:ConfidentialityLevelType ;
+<https://spdx.org/rdf/3/terms/Dataset/ConfidentialityLevelType/clear> a owl:NamedIndividual,
+        ns6:ConfidentialityLevelType ;
     rdfs:label "clear" ;
     rdfs:comment "Dataset may be distributed freely, without restriction."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/ConfidentialityLevelType/green> a owl:NamedIndividual,
-        ns3:ConfidentialityLevelType ;
+<https://spdx.org/rdf/3/terms/Dataset/ConfidentialityLevelType/green> a owl:NamedIndividual,
+        ns6:ConfidentialityLevelType ;
     rdfs:label "green" ;
     rdfs:comment "Dataset can be shared within a community of peers and partners."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/ConfidentialityLevelType/red> a owl:NamedIndividual,
-        ns3:ConfidentialityLevelType ;
+<https://spdx.org/rdf/3/terms/Dataset/ConfidentialityLevelType/red> a owl:NamedIndividual,
+        ns6:ConfidentialityLevelType ;
     rdfs:label "red" ;
     rdfs:comment "Data points in the dataset are highly confidential and can only be shared with named recipients."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetAvailabilityType/clickthrough> a owl:NamedIndividual,
-        ns3:DatasetAvailabilityType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetAvailabilityType/clickthrough> a owl:NamedIndividual,
+        ns6:DatasetAvailabilityType ;
     rdfs:label "clickthrough" ;
     rdfs:comment "Dataset is not publicly available and can only be accessed after affirmatively accepting terms on a clickthrough webpage."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetAvailabilityType/directDownload> a owl:NamedIndividual,
-        ns3:DatasetAvailabilityType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetAvailabilityType/directDownload> a owl:NamedIndividual,
+        ns6:DatasetAvailabilityType ;
     rdfs:label "directDownload" ;
     rdfs:comment "Dataset is publicly available and can be downloaded directly."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetAvailabilityType/query> a owl:NamedIndividual,
-        ns3:DatasetAvailabilityType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetAvailabilityType/query> a owl:NamedIndividual,
+        ns6:DatasetAvailabilityType ;
     rdfs:label "query" ;
     rdfs:comment "Dataset is publicly available, but not all at once, and can only be accessed through queries which return parts of the dataset."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetAvailabilityType/registration> a owl:NamedIndividual,
-        ns3:DatasetAvailabilityType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetAvailabilityType/registration> a owl:NamedIndividual,
+        ns6:DatasetAvailabilityType ;
     rdfs:label "registration" ;
     rdfs:comment "Dataset is not publicly available and an email registration is required before accessing the dataset, although without an affirmative acceptance of terms."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetAvailabilityType/scrapingScript> a owl:NamedIndividual,
-        ns3:DatasetAvailabilityType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetAvailabilityType/scrapingScript> a owl:NamedIndividual,
+        ns6:DatasetAvailabilityType ;
     rdfs:label "scrapingScript" ;
     rdfs:comment "Dataset provider is not making available the underlying data and the dataset shall be reassembled, typically using the provided script for scraping the data."@en .
 
-ns3:DatasetPackage a owl:Class,
+ns6:DatasetPackage a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A Package that contains a dataset."@en ;
-    rdfs:subClassOf ns6:Package ;
+    rdfs:subClassOf ns4:Package ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:datasetUpdateMechanism ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns3:dataPreprocessing ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns3:intendedUse ],
-        [ sh:class ns1:DictionaryEntry ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns3:sensor ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns3:dataCollectionProcess ],
+            sh:path ns6:dataPreprocessing ],
         [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:path ns1:inLanguage ;
             sh:pattern "^[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*$" ],
+        [ sh:class ns1:DictionaryEntry ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns6:sensor ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:datasetNoise ],
-        [ sh:class ns3:DatasetAvailabilityType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Dataset/DatasetAvailabilityType/clickthrough> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetAvailabilityType/directDownload> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetAvailabilityType/query> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetAvailabilityType/registration> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetAvailabilityType/scrapingScript> ) ;
+            sh:path ns6:datasetNoise ],
+        [ sh:class ns6:DatasetAvailabilityType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Dataset/DatasetAvailabilityType/clickthrough> <https://spdx.org/rdf/3/terms/Dataset/DatasetAvailabilityType/directDownload> <https://spdx.org/rdf/3/terms/Dataset/DatasetAvailabilityType/query> <https://spdx.org/rdf/3/terms/Dataset/DatasetAvailabilityType/registration> <https://spdx.org/rdf/3/terms/Dataset/DatasetAvailabilityType/scrapingScript> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns3:datasetAvailability ],
-        [ sh:class ns3:DatasetType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/audio> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/categorical> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/graph> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/image> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/noAssertion> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/numeric> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/other> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/sensor> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/structured> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/syntactic> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/text> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/timeseries> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/timestamp> <https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/video> ) ;
+            sh:path ns6:datasetAvailability ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns6:dataCollectionProcess ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns6:datasetUpdateMechanism ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns6:knownBias ],
+        [ sh:class ns6:DatasetType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Dataset/DatasetType/audio> <https://spdx.org/rdf/3/terms/Dataset/DatasetType/categorical> <https://spdx.org/rdf/3/terms/Dataset/DatasetType/graph> <https://spdx.org/rdf/3/terms/Dataset/DatasetType/image> <https://spdx.org/rdf/3/terms/Dataset/DatasetType/noAssertion> <https://spdx.org/rdf/3/terms/Dataset/DatasetType/numeric> <https://spdx.org/rdf/3/terms/Dataset/DatasetType/other> <https://spdx.org/rdf/3/terms/Dataset/DatasetType/sensor> <https://spdx.org/rdf/3/terms/Dataset/DatasetType/structured> <https://spdx.org/rdf/3/terms/Dataset/DatasetType/syntactic> <https://spdx.org/rdf/3/terms/Dataset/DatasetType/text> <https://spdx.org/rdf/3/terms/Dataset/DatasetType/timeseries> <https://spdx.org/rdf/3/terms/Dataset/DatasetType/timestamp> <https://spdx.org/rdf/3/terms/Dataset/DatasetType/video> ) ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns3:datasetType ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns3:knownBias ],
-        [ sh:class ns3:ConfidentialityLevelType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Dataset/ConfidentialityLevelType/red> <https://spdx.org/rdf/3.1/terms/Dataset/ConfidentialityLevelType/amber> <https://spdx.org/rdf/3.1/terms/Dataset/ConfidentialityLevelType/green> <https://spdx.org/rdf/3.1/terms/Dataset/ConfidentialityLevelType/clear> ) ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns3:confidentialityLevel ],
+            sh:path ns6:datasetType ],
         [ sh:class ns1:PresenceType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/PresenceType/yes> <https://spdx.org/rdf/3.1/terms/Core/PresenceType/no> <https://spdx.org/rdf/3.1/terms/Core/PresenceType/noAssertion> ) ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/PresenceType/yes> <https://spdx.org/rdf/3/terms/Core/PresenceType/no> <https://spdx.org/rdf/3/terms/Core/PresenceType/noAssertion> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns3:hasSensitivePersonalInformation ],
+            sh:path ns6:hasSensitivePersonalInformation ],
+        [ sh:class ns6:ConfidentialityLevelType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Dataset/ConfidentialityLevelType/red> <https://spdx.org/rdf/3/terms/Dataset/ConfidentialityLevelType/amber> <https://spdx.org/rdf/3/terms/Dataset/ConfidentialityLevelType/green> <https://spdx.org/rdf/3/terms/Dataset/ConfidentialityLevelType/clear> ) ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns6:confidentialityLevel ],
         [ sh:datatype xsd:nonNegativeInteger ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:datasetSize ],
+            sh:path ns6:datasetSize ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns6:intendedUse ],
         [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:path ns3:anonymizationMethodUsed ] .
+            sh:path ns6:anonymizationMethodUsed ] .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/audio> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/audio> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "audio" ;
     rdfs:comment "Data is audio based, such as a collection of music from the 80s."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/categorical> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/categorical> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "categorical" ;
     rdfs:comment "Data that is classified into a discrete number of categories, such as the eye color of a population of people."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/graph> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/graph> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "graph" ;
-    rdfs:comment "Data is in the form of a graph where entries are somehow related to each other through edges, such a social network of friends."@en .
+    rdfs:comment "Data is in the form of a graph where entries are somehow related to each other through edges, such as a social network of friends."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/image> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/image> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "image" ;
     rdfs:comment "Data is a collection of images such as pictures of animals."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/noAssertion> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/noAssertion> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "noAssertion" ;
     rdfs:comment "Data type is not known."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/numeric> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/numeric> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "numeric" ;
     rdfs:comment "Data consists only of numeric entries."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/other> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/other> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "other" ;
     rdfs:comment "Data is of a type not included in this list."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/sensor> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/sensor> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "sensor" ;
     rdfs:comment "Data is recorded from a physical sensor, such as a thermometer reading or biometric device."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/structured> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/structured> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "structured" ;
     rdfs:comment "Data is stored in tabular format or retrieved from a relational database."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/syntactic> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/syntactic> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "syntactic" ;
     rdfs:comment "Data describes the syntax or semantics of a language or text, such as a parse tree used for natural language processing."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/text> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/text> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "text" ;
     rdfs:comment "Data consists of unstructured text, such as a book, a Wikipedia article (without images), or a transcript."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/timeseries> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/timeseries> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "timeseries" ;
     rdfs:comment "Data is recorded in an ordered sequence of timestamped entries, such as the price of a stock over the course of a day."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/timestamp> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/timestamp> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "timestamp" ;
     rdfs:comment "Data is recorded with a timestamp for each entry, but not necessarily ordered or at specific intervals, such as when a taxi ride starts and ends."@en .
 
-<https://spdx.org/rdf/3.1/terms/Dataset/DatasetType/video> a owl:NamedIndividual,
-        ns3:DatasetType ;
+<https://spdx.org/rdf/3/terms/Dataset/DatasetType/video> a owl:NamedIndividual,
+        ns6:DatasetType ;
     rdfs:label "video" ;
-    rdfs:comment "Data is video based, such as a collection of movie clips featuring Tom Hanks."@en .
+    rdfs:comment "Data is video based, such as a collection of movie clips."@en .
 
-ns3:anonymizationMethodUsed a owl:DatatypeProperty ;
+ns6:anonymizationMethodUsed a owl:DatatypeProperty ;
     rdfs:comment "Anonymization methods used."@en ;
     rdfs:range xsd:string .
 
-ns3:confidentialityLevel a owl:ObjectProperty ;
+ns6:confidentialityLevel a owl:ObjectProperty ;
     rdfs:comment "Confidentiality level of the data points contained in the dataset."@en ;
-    rdfs:range ns3:ConfidentialityLevelType .
+    rdfs:range ns6:ConfidentialityLevelType .
 
-ns3:dataCollectionProcess a owl:DatatypeProperty ;
+ns6:dataCollectionProcess a owl:DatatypeProperty ;
     rdfs:comment "How the dataset was collected."@en ;
     rdfs:range xsd:string .
 
-ns3:dataPreprocessing a owl:DatatypeProperty ;
+ns6:dataPreprocessing a owl:DatatypeProperty ;
     rdfs:comment "Preprocessing steps that were applied to the raw data to create the given dataset."@en ;
     rdfs:range xsd:string .
 
-ns3:datasetAvailability a owl:ObjectProperty ;
+ns6:datasetAvailability a owl:ObjectProperty ;
     rdfs:comment "Availability of a dataset."@en ;
-    rdfs:range ns3:DatasetAvailabilityType .
+    rdfs:range ns6:DatasetAvailabilityType .
 
-ns3:datasetNoise a owl:DatatypeProperty ;
+ns6:datasetNoise a owl:DatatypeProperty ;
     rdfs:comment "Potentially noisy elements of the dataset."@en ;
     rdfs:range xsd:string .
 
-ns3:datasetSize a owl:DatatypeProperty ;
+ns6:datasetSize a owl:DatatypeProperty ;
     rdfs:comment """**DEPRECATED in SPDX 3.1.**
 Use [/Software/artifactSize](../../Software/Properties/artifactSize.md)
 instead.
@@ -1999,215 +2173,233 @@ instead.
 Size of the dataset."""@en ;
     rdfs:range xsd:nonNegativeInteger .
 
-ns3:datasetType a owl:ObjectProperty ;
+ns6:datasetType a owl:ObjectProperty ;
     rdfs:comment "Type of data in a dataset."@en ;
-    rdfs:range ns3:DatasetType .
+    rdfs:range ns6:DatasetType .
 
-ns3:datasetUpdateMechanism a owl:DatatypeProperty ;
+ns6:datasetUpdateMechanism a owl:DatatypeProperty ;
     rdfs:comment "Mechanism to update the dataset."@en ;
     rdfs:range xsd:string .
 
-ns3:hasSensitivePersonalInformation a owl:ObjectProperty ;
+ns6:hasSensitivePersonalInformation a owl:ObjectProperty ;
     rdfs:comment "Describes if any sensitive personal information is present in the dataset."@en ;
     rdfs:range ns1:PresenceType .
 
-ns3:intendedUse a owl:DatatypeProperty ;
+ns6:intendedUse a owl:DatatypeProperty ;
     rdfs:comment """**DEPRECATED in SPDX 3.1.**
 Use [/Core/intendedUse](../../Core/Properties/intendedUse.md) instead.
 
 The intended use of a given dataset."""@en ;
     rdfs:range xsd:string .
 
-ns3:knownBias a owl:DatatypeProperty ;
+ns6:knownBias a owl:DatatypeProperty ;
     rdfs:comment "Records the biases that the dataset is known to encompass."@en ;
     rdfs:range xsd:string .
 
-ns3:sensor a owl:ObjectProperty ;
+ns6:sensor a owl:ObjectProperty ;
     rdfs:comment "Describes a sensor used for collecting the data."@en ;
     rdfs:range ns1:DictionaryEntry .
 
-ns9:ConjunctiveLicenseSet a owl:Class,
+ns10:ConjunctiveLicenseSet a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Portion of an AnyLicenseInfo representing a set of licensing information
 where all elements apply."""@en ;
-    rdfs:subClassOf <https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo> ;
+    rdfs:subClassOf <https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo> ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class <https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo> ;
+    sh:property [ sh:class <https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo> ;
             sh:minCount 2 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns9:member ] .
+            sh:path ns10:member ] .
 
-ns9:CustomLicense a owl:Class ;
+ns10:CustomLicense a owl:Class ;
     rdfs:comment "A license that is not listed on the SPDX License List."@en ;
-    rdfs:subClassOf ns9:License ;
+    rdfs:subClassOf ns10:License ;
     sh:nodeKind sh:IRI .
 
-ns9:CustomLicenseAddition a owl:Class ;
+ns10:CustomLicenseAddition a owl:Class ;
     rdfs:comment "A license addition that is not listed on the SPDX Exceptions List."@en ;
-    rdfs:subClassOf ns9:LicenseAddition ;
+    rdfs:subClassOf ns10:LicenseAddition ;
     sh:nodeKind sh:IRI .
 
-ns9:DisjunctiveLicenseSet a owl:Class,
+ns10:DisjunctiveLicenseSet a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Portion of an AnyLicenseInfo representing a set of licensing information where
 only one of the elements applies."""@en ;
-    rdfs:subClassOf <https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo> ;
+    rdfs:subClassOf <https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo> ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class <https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo> ;
+    sh:property [ sh:class <https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo> ;
             sh:minCount 2 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns9:member ] .
+            sh:path ns10:member ] .
 
-ns9:ListedLicense a owl:Class,
+ns10:ListedLicense a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A license that is listed on the SPDX License List."@en ;
-    rdfs:subClassOf ns9:License ;
+    rdfs:subClassOf ns10:License ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns9:deprecatedVersion ],
+            sh:path ns10:listVersionAdded ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns9:listVersionAdded ] .
+            sh:path ns10:deprecatedVersion ] .
 
-ns9:ListedLicenseException a owl:Class,
+ns10:ListedLicenseException a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A license exception that is listed on the SPDX Exceptions list."@en ;
-    rdfs:subClassOf ns9:LicenseAddition ;
+    rdfs:subClassOf ns10:LicenseAddition ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns9:deprecatedVersion ],
+            sh:path ns10:listVersionAdded ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns9:listVersionAdded ] .
+            sh:path ns10:deprecatedVersion ] .
 
-ns9:OrLaterOperator a owl:Class,
+ns10:OrLaterOperator a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Portion of an AnyLicenseInfo representing this version, or any later version,
 of the indicated License."""@en ;
-    rdfs:subClassOf ns9:ExtendableLicense ;
+    rdfs:subClassOf ns10:ExtendableLicense ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns9:License ;
+    sh:property [ sh:class ns10:License ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns9:subjectLicense ] .
+            sh:path ns10:subjectLicense ] .
 
-ns9:WithAdditionOperator a owl:Class,
+ns10:WithAdditionOperator a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Portion of an AnyLicenseInfo representing a License which has additional
 text applied to it."""@en ;
-    rdfs:subClassOf <https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo> ;
+    rdfs:subClassOf <https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo> ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns9:LicenseAddition ;
+    sh:property [ sh:class ns10:ExtendableLicense ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns9:subjectAddition ],
-        [ sh:class ns9:ExtendableLicense ;
+            sh:path ns10:subjectExtendableLicense ],
+        [ sh:class ns10:LicenseAddition ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns9:subjectExtendableLicense ] .
+            sh:path ns10:subjectAddition ] .
 
-ns9:additionText a owl:DatatypeProperty ;
+ns10:additionText a owl:DatatypeProperty ;
     rdfs:comment "Identifies the full text of a LicenseAddition."@en ;
     rdfs:range xsd:string .
 
-ns9:isDeprecatedAdditionId a owl:DatatypeProperty ;
+ns10:isDeprecatedAdditionId a owl:DatatypeProperty ;
     rdfs:comment "Specifies whether an additional text identifier has been marked as deprecated."@en ;
     rdfs:range xsd:boolean .
 
-ns9:isDeprecatedLicenseId a owl:DatatypeProperty ;
+ns10:isDeprecatedLicenseId a owl:DatatypeProperty ;
     rdfs:comment """Specifies whether a license or additional text identifier has been marked as
 deprecated."""@en ;
     rdfs:range xsd:boolean .
 
-ns9:isFsfLibre a owl:DatatypeProperty ;
+ns10:isFsfLibre a owl:DatatypeProperty ;
     rdfs:comment """Specifies whether the License is listed as free by the
 Free Software Foundation (FSF)."""@en ;
     rdfs:range xsd:boolean .
 
-ns9:isOsiApproved a owl:DatatypeProperty ;
+ns10:isOsiApproved a owl:DatatypeProperty ;
     rdfs:comment """Specifies whether the License is listed as approved by the
 Open Source Initiative (OSI)."""@en ;
     rdfs:range xsd:boolean .
 
-ns9:standardAdditionTemplate a owl:DatatypeProperty ;
+ns10:standardAdditionTemplate a owl:DatatypeProperty ;
     rdfs:comment "Identifies the full text of a LicenseAddition, in SPDX templating format."@en ;
     rdfs:range xsd:string .
 
-ns9:standardLicenseHeader a owl:DatatypeProperty ;
+ns10:standardLicenseHeader a owl:DatatypeProperty ;
     rdfs:comment """Provides a License author's preferred text to indicate that a file is covered
 by the License."""@en ;
     rdfs:range xsd:string .
 
-ns9:standardLicenseTemplate a owl:DatatypeProperty ;
+ns10:standardLicenseTemplate a owl:DatatypeProperty ;
     rdfs:comment "Identifies the full text of a License, in SPDX templating format."@en ;
     rdfs:range xsd:string .
 
-ns9:subjectAddition a owl:ObjectProperty ;
+ns10:subjectAddition a owl:ObjectProperty ;
     rdfs:comment "A LicenseAddition participating in a 'with addition' model."@en ;
-    rdfs:range ns9:LicenseAddition .
+    rdfs:range ns10:LicenseAddition .
 
-ns9:subjectExtendableLicense a owl:ObjectProperty ;
+ns10:subjectExtendableLicense a owl:ObjectProperty ;
     rdfs:comment "A License participating in a 'with addition' model."@en ;
-    rdfs:range ns9:ExtendableLicense .
+    rdfs:range ns10:ExtendableLicense .
 
-ns9:subjectLicense a owl:ObjectProperty ;
+ns10:subjectLicense a owl:ObjectProperty ;
     rdfs:comment "A License participating in an 'or later' model."@en ;
-    rdfs:range ns9:License .
+    rdfs:range ns10:License .
 
-<https://spdx.org/rdf/3.1/terms/Extension/cdxPropName> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Extension/cdxPropName> a owl:DatatypeProperty ;
     rdfs:comment "A name used in a CdxPropertyEntry name-value pair."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/Extension/cdxPropValue> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Extension/cdxPropValue> a owl:DatatypeProperty ;
     rdfs:comment "A value used in a CdxPropertyEntry name-value pair."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/Extension/cdxProperty> a owl:ObjectProperty ;
+<https://spdx.org/rdf/3/terms/Extension/cdxProperty> a owl:ObjectProperty ;
     rdfs:comment "Provides a map of a property name to a value."@en ;
-    rdfs:range <https://spdx.org/rdf/3.1/terms/Extension/CdxPropertyEntry> .
+    rdfs:range <https://spdx.org/rdf/3/terms/Extension/CdxPropertyEntry> .
+
+ns2:Assumption a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "A distinct unit representing a constraint associated with an item's use in a system."@en ;
+    rdfs:subClassOf ns1:Element ;
+    sh:nodeKind sh:IRI ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:rationale ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:assumptionStatement ],
+        [ sh:class ns1:ExternalIdentifier ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns2:assumptionUID ] .
 
 ns2:EvaluationResult a owl:Class,
         sh:NodeShape ;
     rdfs:comment "EvaluationResult is the result of an evaluation."@en ;
     rdfs:subClassOf ns1:Element ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns2:RequirementVerification ;
+    sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns2:evaluationBasedOn ],
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:rationale ],
         [ sh:class ns2:EvaluationResultType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvaluationResultType/pass> <https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvaluationResultType/fail> <https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvaluationResultType/inconclusive> ) ;
+            sh:in ( <https://spdx.org/rdf/3/terms/FunctionalSafety/EvaluationResultType/pass> <https://spdx.org/rdf/3/terms/FunctionalSafety/EvaluationResultType/fail> <https://spdx.org/rdf/3/terms/FunctionalSafety/EvaluationResultType/inconclusive> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:path ns2:evaluation ],
-        [ sh:datatype xsd:string ;
+        [ sh:class ns2:RequirementVerification ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns2:evaluationRationale ] .
+            sh:nodeKind sh:IRI ;
+            sh:path ns2:evaluationBasedOn ] .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvaluationResultType/fail> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/EvaluationResultType/fail> a owl:NamedIndividual,
         ns2:EvaluationResultType ;
     rdfs:label "fail" ;
     rdfs:comment "Indicates a failed evaluation where the requirement or condition is not met."@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvaluationResultType/inconclusive> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/EvaluationResultType/inconclusive> a owl:NamedIndividual,
         ns2:EvaluationResultType ;
     rdfs:label "inconclusive" ;
     rdfs:comment "Inconclusive refers to a result or outcome from a verification, test, or analysis that cannot be clearly classified as either positive (successful, pass) or negative (failed, reject). An inconclusive result means there was not enough clear evidence, data, or signal to make a definitive determination, and further investigation or additional testing is necessary. An inconclusive result always shall need a comment on it."@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvaluationResultType/pass> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/EvaluationResultType/pass> a owl:NamedIndividual,
         ns2:EvaluationResultType ;
     rdfs:label "pass" ;
     rdfs:comment "Indicates a successful evaluation where the requirement or condition is clearly met."@en .
@@ -2218,78 +2410,86 @@ ns2:EvidenceRelationship a owl:Class,
     rdfs:subClassOf ns1:Relationship ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:class ns2:EvidenceType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvidenceType/report> <https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvidenceType/log> <https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvidenceType/recording> <https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvidenceType/observation> <https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvidenceType/other> ) ;
+            sh:in ( <https://spdx.org/rdf/3/terms/FunctionalSafety/EvidenceType/report> <https://spdx.org/rdf/3/terms/FunctionalSafety/EvidenceType/log> <https://spdx.org/rdf/3/terms/FunctionalSafety/EvidenceType/recording> <https://spdx.org/rdf/3/terms/FunctionalSafety/EvidenceType/observation> <https://spdx.org/rdf/3/terms/FunctionalSafety/EvidenceType/other> ) ;
             sh:nodeKind sh:IRI ;
             sh:path ns2:evidenceCategory ],
         [ sh:class ns1:ExternalIdentifier ;
             sh:maxCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns2:evidenceUUID ] .
+            sh:path ns2:evidenceUID ] .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvidenceType/log> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/EvidenceType/log> a owl:NamedIndividual,
         ns2:EvidenceType ;
     rdfs:label "log" ;
     rdfs:comment "Time-stamped records capturing system or operational data recorded as usually as a response to specific triggers in a specified environment."@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvidenceType/observation> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/EvidenceType/observation> a owl:NamedIndividual,
         ns2:EvidenceType ;
     rdfs:label "observation" ;
     rdfs:comment "Documentation of direct monitoring or witnessing of the demonstration of processes, tests, or any kind of system responses during a specified timeframe under specified environmental conditions."@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvidenceType/other> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/EvidenceType/other> a owl:NamedIndividual,
         ns2:EvidenceType ;
     rdfs:label "other" ;
     rdfs:comment "Any other relevant type of proof or documentation not covered above."@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvidenceType/recording> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/EvidenceType/recording> a owl:NamedIndividual,
         ns2:EvidenceType ;
     rdfs:label "recording" ;
     rdfs:comment "Captured datastream like audio, video, or any other kind of continuous electronic capture of events, behavior or conditions."@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/EvidenceType/report> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/EvidenceType/report> a owl:NamedIndividual,
         ns2:EvidenceType ;
     rdfs:label "report" ;
     rdfs:comment "Structured documentation of test results, inspections, or analyses."@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/analysis> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/analysis> a owl:NamedIndividual,
         ns2:VerificationType ;
     rdfs:label "analysis" ;
     rdfs:comment "Analytical evaluating of data, designs, or processes methodically to verify correctness against standards or expectations. Typical analysis methods are FMEA, FTA, STPA, static analysis for MISRA compliance etc."@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/assessment> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/assessment> a owl:NamedIndividual,
         ns2:VerificationType ;
     rdfs:label "assessment" ;
     rdfs:comment "A systematic examination of a system, process, or outcome to evaluate compliance of specific work products with a specific expectation with a specification, regulation or standard. Often involves judgement and a rationale of this judgement."@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/audit> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/audit> a owl:NamedIndividual,
         ns2:VerificationType ;
     rdfs:label "audit" ;
     rdfs:comment "An examination typically focusing on compliance with policies, standards, or regulations. Usually this is done during an audit meeting, while the assessment also involves deep and detailed reviews of work products (e.g. requirements, verification specifications, reports etc.)"@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/demonstration> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/demonstration> a owl:NamedIndividual,
         ns2:VerificationType ;
     rdfs:label "demonstration" ;
     rdfs:comment "Demonstrating and monitoring or recording that the item under verification to confirm that a requirement is met by the item under verification."@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/inspection> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/inspection> a owl:NamedIndividual,
         ns2:VerificationType ;
     rdfs:label "inspection" ;
     rdfs:comment "A thorough examination or checking of documentation, records, processes, or systems to confirm compliance or adherence. An inspection needs to have a defined set of acceptance criteria (e.g. a checklist), a documentation of roles involved in the inspection (e.g. to document the inspector's independence) and a clear documentation of when and how it was performed."@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/other> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/other> a owl:NamedIndividual,
         ns2:VerificationType ;
     rdfs:label "other" ;
     rdfs:comment "Any other specialized or custom verification method that fits the context."@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/review> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/review> a owl:NamedIndividual,
         ns2:VerificationType ;
     rdfs:label "review" ;
     rdfs:comment "A examination or checking of documentation, records, processes, or systems to confirm compliance or adherence with an upper level requirement. Typically done as peer review, offline review or review meeting."@en .
 
-<https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/test> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/test> a owl:NamedIndividual,
         ns2:VerificationType ;
     rdfs:label "test" ;
     rdfs:comment "Conducting controlled tests, experiments or simulations to verify that specific requirements regarding performance, functionality, robustness, etc. are met."@en .
+
+ns2:assumptionStatement a owl:DatatypeProperty ;
+    rdfs:comment "A text describing the design constraint defined by the assumption."@en ;
+    rdfs:range xsd:string .
+
+ns2:assumptionUID a owl:ObjectProperty ;
+    rdfs:comment "An assumptionUID is a unique identifier assigned to an Assumption item."@en ;
+    rdfs:range ns1:ExternalIdentifier .
 
 ns2:evaluation a owl:DatatypeProperty ;
     rdfs:comment "Evaluation is an outcome considering results of a verification."@en ;
@@ -2299,16 +2499,13 @@ ns2:evaluationBasedOn a owl:ObjectProperty ;
     rdfs:comment "Indicates the specific RequirementVerification instance on which the EvaluationResult is based."@en ;
     rdfs:range ns2:RequirementVerification .
 
-ns2:evaluationRationale a owl:DatatypeProperty ;
-    rdfs:comment "Detailed explanation or reasoning that supports the EvaluationResult."@en ;
-    rdfs:range xsd:string .
-
 ns2:evidenceCategory a owl:ObjectProperty ;
     rdfs:comment "evidenceCategory refers to a category of documented or observable proof."@en ;
     rdfs:range ns2:EvidenceType .
 
-ns2:evidenceUUID a owl:ObjectProperty ;
-    rdfs:comment "A evidenceUUID is a universally unique identifier (UUID) assigned to an entity, item, or requirement."@en ;
+ns2:evidenceUID a owl:ObjectProperty ;
+    rdfs:comment """A evidenceUID is a unique identifier assigned to an entity, item,
+or requirement."""@en ;
     rdfs:range ns1:ExternalIdentifier .
 
 ns2:verificationMethod a owl:DatatypeProperty ;
@@ -2323,44 +2520,40 @@ ns2:verificationPrecondition a owl:DatatypeProperty ;
     rdfs:comment "Verification preconditions are initial criteria that are to be met prior to initiating the verification method."@en ;
     rdfs:range xsd:string .
 
-ns2:verificationRationale a owl:DatatypeProperty ;
-    rdfs:comment "A verificationRationale is supporting information that justifies the verification details."@en ;
-    rdfs:range xsd:string .
-
-ns2:verificationUUID a owl:ObjectProperty ;
-    rdfs:comment "A verificationUUID is a universally unique identifier (UUID) assigned to a Verification item."@en ;
+ns2:verificationUID a owl:ObjectProperty ;
+    rdfs:comment "A verificationUID is a unique identifier assigned to a Verification item."@en ;
     rdfs:range ns1:ExternalIdentifier .
 
-ns10:BulkHardware a owl:Class,
+ns3:BulkHardware a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Products or commodities produced as a bulk unit are called bulk products. Commodities are often sold in bulk."@en ;
-    rdfs:subClassOf ns10:Hardware ;
+    rdfs:subClassOf ns3:Hardware ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:class ns1:UnitOfMeasure ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns10:bulkQuantity ] .
+            sh:path ns3:bulkQuantity ] .
 
-ns10:PhysicalHardware a owl:Class,
+ns3:PhysicalHardware a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Class that describes a physical instance of Hardware."@en ;
-    rdfs:subClassOf ns10:Hardware ;
+    rdfs:subClassOf ns3:Hardware ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns10:Dimensions ;
+    sh:property [ sh:class ns3:Dimensions ;
             sh:maxCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns10:dimensions ],
-        [ sh:class ns10:Dimensions ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns10:centerOfMass ],
+            sh:path ns3:dimensions ],
         [ sh:class ns1:MeasureOfMass ;
             sh:maxCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns10:massOfHardware ] .
+            sh:path ns3:massOfHardware ],
+        [ sh:class ns3:Dimensions ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns3:centerOfMass ] .
 
-ns10:ProductSpecification a owl:Class,
+ns3:ProductSpecification a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A product specification (product spec) is a detailed document that outlines the technical, functional, and design requirements of a product."@en ;
     rdfs:subClassOf ns1:Specification ;
@@ -2368,412 +2561,397 @@ ns10:ProductSpecification a owl:Class,
     sh:property [ sh:datatype xsd:string ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns10:partNumber ],
+            sh:path ns3:partNumber ],
         [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:path ns10:itemVersion ],
+            sh:path ns1:version ],
         [ sh:class ns1:DefinedType ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns10:hazard ] .
+            sh:path ns3:hazard ] .
 
-ns10:VirtualHardware a owl:Class,
+ns3:VirtualHardware a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Class that describes an instance of VirtualHardware."@en ;
-    rdfs:subClassOf ns10:Hardware ;
+    rdfs:subClassOf ns3:Hardware ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns10:VirtualHardwareModelType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Hardware/VirtualHardwareModelType/function> <https://spdx.org/rdf/3.1/terms/Hardware/VirtualHardwareModelType/cycle> <https://spdx.org/rdf/3.1/terms/Hardware/VirtualHardwareModelType/other> ) ;
+    sh:property [ sh:class ns3:VirtualHardwareModelType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Hardware/VirtualHardwareModelType/function> <https://spdx.org/rdf/3/terms/Hardware/VirtualHardwareModelType/cycle> <https://spdx.org/rdf/3/terms/Hardware/VirtualHardwareModelType/other> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns10:virtualHardwareModel ] .
+            sh:path ns3:virtualHardwareModel ] .
 
-<https://spdx.org/rdf/3.1/terms/Hardware/VirtualHardwareModelType/cycle> a owl:NamedIndividual,
-        ns10:VirtualHardwareModelType ;
+<https://spdx.org/rdf/3/terms/Hardware/VirtualHardwareModelType/cycle> a owl:NamedIndividual,
+        ns3:VirtualHardwareModelType ;
     rdfs:label "cycle" ;
     rdfs:comment "Simulation architectures with precise cycle-level accuracy."@en .
 
-<https://spdx.org/rdf/3.1/terms/Hardware/VirtualHardwareModelType/function> a owl:NamedIndividual,
-        ns10:VirtualHardwareModelType ;
+<https://spdx.org/rdf/3/terms/Hardware/VirtualHardwareModelType/function> a owl:NamedIndividual,
+        ns3:VirtualHardwareModelType ;
     rdfs:label "function" ;
     rdfs:comment "Simulation the function of the hardware."@en .
 
-<https://spdx.org/rdf/3.1/terms/Hardware/VirtualHardwareModelType/other> a owl:NamedIndividual,
-        ns10:VirtualHardwareModelType ;
+<https://spdx.org/rdf/3/terms/Hardware/VirtualHardwareModelType/other> a owl:NamedIndividual,
+        ns3:VirtualHardwareModelType ;
     rdfs:label "other" ;
     rdfs:comment "All other simulation types."@en .
 
-ns10:additionalInformation a owl:ObjectProperty ;
+ns3:additionalInformation a owl:ObjectProperty ;
     rdfs:comment "Additional relevance information."@en ;
     rdfs:range ns1:DictionaryEntry .
 
-ns10:additionalInformationSpecification a owl:ObjectProperty ;
+ns3:additionalInformationSpecification a owl:ObjectProperty ;
     rdfs:comment "It is the authoritative or credible entity, document, or body of knowledge that provides the meaning of an additionalInformation key and/or its values, ensuring accuracy, context, and standardization."@en ;
     rdfs:range ns1:Specification .
 
-ns10:batchNumber a owl:DatatypeProperty ;
+ns3:batchNumber a owl:DatatypeProperty ;
     rdfs:comment "Identifier for product production batch."@en ;
     rdfs:range xsd:string .
 
-ns10:bulkQuantity a owl:ObjectProperty ;
+ns3:bulkQuantity a owl:ObjectProperty ;
     rdfs:comment "The amount or measure of a bulk product."@en ;
     rdfs:range ns1:UnitOfMeasure .
 
-ns10:category a owl:ObjectProperty ;
+ns3:category a owl:ObjectProperty ;
     rdfs:comment "The category describes the hardware item in a DefinedType."@en ;
     rdfs:range ns1:DefinedType .
 
-ns10:centerOfMass a owl:ObjectProperty ;
+ns3:centerOfMass a owl:ObjectProperty ;
     rdfs:comment "A point representing the mean position of the matter in a body or system."@en ;
-    rdfs:range ns10:Dimensions .
+    rdfs:range ns3:Dimensions .
 
-ns10:dimensions a owl:ObjectProperty ;
+ns3:dimensions a owl:ObjectProperty ;
     rdfs:comment "Information related to hardware dimension."@en ;
-    rdfs:range ns10:Dimensions .
+    rdfs:range ns3:Dimensions .
 
-ns10:hardwareVersion a owl:DatatypeProperty ;
-    rdfs:comment "Version identifier for the hardware product."@en ;
-    rdfs:range xsd:string .
-
-ns10:itemVersion a owl:DatatypeProperty ;
-    rdfs:comment "Version identifier for the item."@en ;
-    rdfs:range xsd:string .
-
-ns10:massOfHardware a owl:DatatypeProperty ;
+ns3:massOfHardware a owl:DatatypeProperty ;
     rdfs:comment "Information related to massOfHardware physical hardware."@en ;
     rdfs:range ns1:MeasureOfMass .
 
-ns10:productAgent a owl:ObjectProperty ;
-    rdfs:comment "The Agent who is responsible for product branding such as an OEM."@en ;
+ns3:productAgent a owl:ObjectProperty ;
+    rdfs:comment """An Agent responsible for product identification,
+such as an original equipment manufacturer (OEM)."""@en ;
     rdfs:range ns1:Agent .
 
-ns10:releaseDate a owl:ObjectProperty ;
+ns3:releaseDate a owl:ObjectProperty ;
     rdfs:comment "Date of product release."@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns10:serialNumber a owl:DatatypeProperty ;
+ns3:serialNumber a owl:DatatypeProperty ;
     rdfs:comment "Identifier for specific product is called a serial number."@en ;
     rdfs:range xsd:string .
 
-ns10:virtualHardwareModel a owl:DatatypeProperty ;
+ns3:virtualHardwareModel a owl:DatatypeProperty ;
     rdfs:comment "Information related to virtual hardware simulation."@en ;
-    rdfs:range ns10:VirtualHardwareModelType .
+    rdfs:range ns3:VirtualHardwareModelType .
 
-ns10:xAxisLength a owl:ObjectProperty ;
+ns3:xAxisLength a owl:ObjectProperty ;
     rdfs:comment "Information related to hardware dimension."@en ;
     rdfs:range ns1:MeasureOfLength .
 
-ns10:yAxisLength a owl:ObjectProperty ;
+ns3:yAxisLength a owl:ObjectProperty ;
     rdfs:comment "Information related to hardware dimension."@en ;
     rdfs:range ns1:MeasureOfLength .
 
-ns10:zAxisLength a owl:ObjectProperty ;
+ns3:zAxisLength a owl:ObjectProperty ;
     rdfs:comment "Information related to hardware dimension."@en ;
     rdfs:range ns1:MeasureOfLength .
 
-<https://spdx.org/rdf/3.1/terms/Operations/ExportControlClassificationAssessment> a owl:Class,
+<https://spdx.org/rdf/3/terms/Operations/ExportControlClassificationAssessment> a owl:Class,
         sh:NodeShape ;
-    rdfs:comment "Assement of an Element for export control classification."@en ;
+    rdfs:comment "Assessment of an Element for export control classification."@en ;
     rdfs:subClassOf ns1:Artifact ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/assessmentTimestamp> ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:class <https://spdx.org/rdf/3.1/terms/Operations/ExportControlClassification> ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/assessmentResult> ],
+            sh:path <https://spdx.org/rdf/3/terms/Operations/assessmentTime> ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
         [ sh:class ns1:Agent ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/assessor> ],
+            sh:path <https://spdx.org/rdf/3/terms/Operations/assessor> ],
+        [ sh:class <https://spdx.org/rdf/3/terms/Operations/Project> ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path <https://spdx.org/rdf/3/terms/Operations/assessmentContext> ],
         [ sh:class ns1:Element ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/assessedElement> ],
-        [ sh:class <https://spdx.org/rdf/3.1/terms/Operations/Project> ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/assessmentContext> ] .
+            sh:path <https://spdx.org/rdf/3/terms/Operations/assessedElement> ],
+        [ sh:class <https://spdx.org/rdf/3/terms/Operations/ExportControlClassification> ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <https://spdx.org/rdf/3/terms/Operations/assessmentResult> ] .
 
-<https://spdx.org/rdf/3.1/terms/Operations/assessedElement> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Operations/assessedElement> a owl:DatatypeProperty ;
     rdfs:comment "Specifies an Element as subject of an assessment."@en ;
     rdfs:range ns1:Element .
 
-<https://spdx.org/rdf/3.1/terms/Operations/assessmentContext> a owl:DatatypeProperty ;
-    rdfs:comment "Sets the context for an assessment iby specifying the related project."@en ;
-    rdfs:range <https://spdx.org/rdf/3.1/terms/Operations/Project> .
+<https://spdx.org/rdf/3/terms/Operations/assessmentContext> a owl:DatatypeProperty ;
+    rdfs:comment "Sets the context for an assessment by specifying the related project."@en ;
+    rdfs:range <https://spdx.org/rdf/3/terms/Operations/Project> .
 
-<https://spdx.org/rdf/3.1/terms/Operations/assessmentResult> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Operations/assessmentResult> a owl:DatatypeProperty ;
     rdfs:comment "Specifies an Element as subject of an assessment."@en ;
-    rdfs:range <https://spdx.org/rdf/3.1/terms/Operations/ExportControlClassification> .
+    rdfs:range <https://spdx.org/rdf/3/terms/Operations/ExportControlClassification> .
 
-<https://spdx.org/rdf/3.1/terms/Operations/assessmentTimestamp> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Operations/assessmentTime> a owl:DatatypeProperty ;
     rdfs:comment "Timestamp, when an assessment was conducted."@en ;
     rdfs:range xsd:dateTimeStamp .
 
-<https://spdx.org/rdf/3.1/terms/Operations/assessor> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Operations/assessor> a owl:DatatypeProperty ;
     rdfs:comment "An entity providing an assessment."@en ;
     rdfs:range ns1:Agent .
 
-<https://spdx.org/rdf/3.1/terms/Operations/exportClassification> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Operations/exportClassification> a owl:DatatypeProperty ;
     rdfs:comment "Expression for the export control classification."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/Operations/exportControlSpecification> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Operations/exportControlSpecification> a owl:DatatypeProperty ;
     rdfs:comment "Specification basis for the export control classification."@en ;
     rdfs:range ns1:Specification .
 
-<https://spdx.org/rdf/3.1/terms/Operations/exportingCountry> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Operations/exportingCountry> a owl:DatatypeProperty ;
     rdfs:comment "Country for which export controls must be taken into account."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/Operations/projectContract> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Operations/projectContract> a owl:DatatypeProperty ;
     rdfs:comment "Link to the project contract."@en ;
     rdfs:range xsd:anyURI .
 
-<https://spdx.org/rdf/3.1/terms/Operations/projectEndTime> a owl:DatatypeProperty ;
-    rdfs:comment "Time when the project ends or is planned to end."@en ;
-    rdfs:range xsd:dateTimeStamp .
-
-<https://spdx.org/rdf/3.1/terms/Operations/projectOwner> a owl:DatatypeProperty ;
-    rdfs:comment "Owner or Lead of the project."@en ;
+<https://spdx.org/rdf/3/terms/Operations/projectOwner> a owl:DatatypeProperty ;
+    rdfs:comment "Owner or lead of the project."@en ;
     rdfs:range ns1:Agent .
 
-<https://spdx.org/rdf/3.1/terms/Operations/projectSponsor> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Operations/projectSponsor> a owl:DatatypeProperty ;
     rdfs:comment "Sponsor of the project."@en ;
     rdfs:range ns1:Agent .
 
-<https://spdx.org/rdf/3.1/terms/Operations/projectStartTime> a owl:DatatypeProperty ;
-    rdfs:comment "Time when the project starts or is planned to start."@en ;
-    rdfs:range xsd:dateTimeStamp .
-
-<https://spdx.org/rdf/3.1/terms/Operations/projectTitle> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/Operations/projectTitle> a owl:DatatypeProperty ;
     rdfs:comment "Title of the project."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/Operations/weight> a owl:ObjectProperty ;
+<https://spdx.org/rdf/3/terms/Operations/weight> a owl:ObjectProperty ;
     rdfs:comment "Weight to express relevance in de minimis consideration."@en ;
     rdfs:range xsd:positiveInteger .
 
-ns4:CvssV2VulnAssessmentRelationship a owl:Class,
+ns5:CvssV2VulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Provides a CVSS version 2.0 assessment for a vulnerability."@en ;
-    rdfs:subClassOf ns4:VulnAssessmentRelationship ;
-    sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns4:vectorString ],
-        [ sh:datatype xsd:decimal ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns4:score ] .
-
-ns4:CvssV3VulnAssessmentRelationship a owl:Class,
-        sh:NodeShape ;
-    rdfs:comment "Provides a CVSS version 3 assessment for a vulnerability."@en ;
-    rdfs:subClassOf ns4:VulnAssessmentRelationship ;
+    rdfs:subClassOf ns5:VulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:decimal ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:score ],
-        [ sh:class ns4:CvssSeverityType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/critical> <https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/high> <https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/medium> <https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/low> <https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/none> ) ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns4:severity ],
+            sh:path ns5:score ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:vectorString ] .
+            sh:path ns5:vectorString ] .
 
-ns4:CvssV4VulnAssessmentRelationship a owl:Class,
+ns5:CvssV3VulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
-    rdfs:comment "Provides a CVSS version 4 assessment for a vulnerability."@en ;
-    rdfs:subClassOf ns4:VulnAssessmentRelationship ;
-    sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns4:vectorString ],
-        [ sh:datatype xsd:decimal ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns4:score ],
-        [ sh:class ns4:CvssSeverityType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/critical> <https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/high> <https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/medium> <https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/low> <https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/none> ) ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns4:severity ] .
-
-ns4:EpssVulnAssessmentRelationship a owl:Class,
-        sh:NodeShape ;
-    rdfs:comment "Provides an EPSS assessment for a vulnerability."@en ;
-    rdfs:subClassOf ns4:VulnAssessmentRelationship ;
+    rdfs:comment "Provides a CVSS version 3 assessment for a vulnerability."@en ;
+    rdfs:subClassOf ns5:VulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:decimal ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:percentile ],
+            sh:path ns5:score ],
+        [ sh:class ns5:CvssSeverityType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Security/CvssSeverityType/critical> <https://spdx.org/rdf/3/terms/Security/CvssSeverityType/high> <https://spdx.org/rdf/3/terms/Security/CvssSeverityType/medium> <https://spdx.org/rdf/3/terms/Security/CvssSeverityType/low> <https://spdx.org/rdf/3/terms/Security/CvssSeverityType/none> ) ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns5:severity ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns5:vectorString ] .
+
+ns5:CvssV4VulnAssessmentRelationship a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "Provides a CVSS version 4 assessment for a vulnerability."@en ;
+    rdfs:subClassOf ns5:VulnAssessmentRelationship ;
+    sh:nodeKind sh:IRI ;
+    sh:property [ sh:datatype xsd:decimal ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns5:score ],
+        [ sh:class ns5:CvssSeverityType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Security/CvssSeverityType/critical> <https://spdx.org/rdf/3/terms/Security/CvssSeverityType/high> <https://spdx.org/rdf/3/terms/Security/CvssSeverityType/medium> <https://spdx.org/rdf/3/terms/Security/CvssSeverityType/low> <https://spdx.org/rdf/3/terms/Security/CvssSeverityType/none> ) ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns5:severity ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns5:vectorString ] .
+
+ns5:EpssVulnAssessmentRelationship a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "Provides an EPSS assessment for a vulnerability."@en ;
+    rdfs:subClassOf ns5:VulnAssessmentRelationship ;
+    sh:nodeKind sh:IRI ;
+    sh:property [ sh:datatype xsd:decimal ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns5:percentile ],
         [ sh:datatype xsd:decimal ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:probability ] .
+            sh:path ns5:probability ] .
 
-<https://spdx.org/rdf/3.1/terms/Security/ExploitCatalogType/kev> a owl:NamedIndividual,
-        ns4:ExploitCatalogType ;
+<https://spdx.org/rdf/3/terms/Security/ExploitCatalogType/kev> a owl:NamedIndividual,
+        ns5:ExploitCatalogType ;
     rdfs:label "kev" ;
     rdfs:comment "CISA's Known Exploited Vulnerability (KEV) catalog."@en .
 
-<https://spdx.org/rdf/3.1/terms/Security/ExploitCatalogType/other> a owl:NamedIndividual,
-        ns4:ExploitCatalogType ;
+<https://spdx.org/rdf/3/terms/Security/ExploitCatalogType/other> a owl:NamedIndividual,
+        ns5:ExploitCatalogType ;
     rdfs:label "other" ;
     rdfs:comment "Other exploit catalogs."@en .
 
-ns4:ExploitCatalogVulnAssessmentRelationship a owl:Class,
+ns5:ExploitCatalogVulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Provides an exploit assessment of a vulnerability."@en ;
-    rdfs:subClassOf ns4:VulnAssessmentRelationship ;
+    rdfs:subClassOf ns5:VulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns4:ExploitCatalogType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Security/ExploitCatalogType/kev> <https://spdx.org/rdf/3.1/terms/Security/ExploitCatalogType/other> ) ;
+    sh:property [ sh:class ns5:ExploitCatalogType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Security/ExploitCatalogType/kev> <https://spdx.org/rdf/3/terms/Security/ExploitCatalogType/other> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns4:catalogType ],
-        [ sh:datatype xsd:anyURI ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns4:locator ],
+            sh:path ns5:catalogType ],
         [ sh:datatype xsd:boolean ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:exploited ] .
+            sh:path ns5:exploited ],
+        [ sh:datatype xsd:anyURI ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns5:locator ] .
 
-<https://spdx.org/rdf/3.1/terms/Security/SsvcDecisionType/act> a owl:NamedIndividual,
-        ns4:SsvcDecisionType ;
+<https://spdx.org/rdf/3/terms/Security/SsvcDecisionType/act> a owl:NamedIndividual,
+        ns5:SsvcDecisionType ;
     rdfs:label "act" ;
     rdfs:comment "The vulnerability requires attention from the organization's internal, supervisory-level and leadership-level individuals. Necessary actions include requesting assistance or information about the vulnerability, as well as publishing a notification either internally and/or externally. Typically, internal groups would meet to determine the overall response and then execute agreed upon actions. CISA recommends remediating Act vulnerabilities as soon as possible."@en .
 
-<https://spdx.org/rdf/3.1/terms/Security/SsvcDecisionType/attend> a owl:NamedIndividual,
-        ns4:SsvcDecisionType ;
+<https://spdx.org/rdf/3/terms/Security/SsvcDecisionType/attend> a owl:NamedIndividual,
+        ns5:SsvcDecisionType ;
     rdfs:label "attend" ;
     rdfs:comment "The vulnerability requires attention from the organization's internal, supervisory-level individuals. Necessary actions include requesting assistance or information about the vulnerability, and may involve publishing a notification either internally and/or externally. CISA recommends remediating Attend vulnerabilities sooner than standard update timelines."@en .
 
-<https://spdx.org/rdf/3.1/terms/Security/SsvcDecisionType/track> a owl:NamedIndividual,
-        ns4:SsvcDecisionType ;
+<https://spdx.org/rdf/3/terms/Security/SsvcDecisionType/track> a owl:NamedIndividual,
+        ns5:SsvcDecisionType ;
     rdfs:label "track" ;
     rdfs:comment "The vulnerability does not require action at this time. The organization would continue to track the vulnerability and reassess it if new information becomes available. CISA recommends remediating Track vulnerabilities within standard update timelines."@en .
 
-<https://spdx.org/rdf/3.1/terms/Security/SsvcDecisionType/trackStar> a owl:NamedIndividual,
-        ns4:SsvcDecisionType ;
+<https://spdx.org/rdf/3/terms/Security/SsvcDecisionType/trackStar> a owl:NamedIndividual,
+        ns5:SsvcDecisionType ;
     rdfs:label "trackStar" ;
     rdfs:comment "(\"Track\\*\" in the SSVC spec) The vulnerability contains specific characteristics that may require closer monitoring for changes. CISA recommends remediating Track\\* vulnerabilities within standard update timelines."@en .
 
-ns4:SsvcVulnAssessmentRelationship a owl:Class,
+ns5:SsvcVulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Provides an SSVC assessment for a vulnerability."@en ;
-    rdfs:subClassOf ns4:VulnAssessmentRelationship ;
+    rdfs:subClassOf ns5:VulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns4:SsvcDecisionType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Security/SsvcDecisionType/act> <https://spdx.org/rdf/3.1/terms/Security/SsvcDecisionType/attend> <https://spdx.org/rdf/3.1/terms/Security/SsvcDecisionType/track> <https://spdx.org/rdf/3.1/terms/Security/SsvcDecisionType/trackStar> ) ;
+    sh:property [ sh:class ns5:SsvcDecisionType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Security/SsvcDecisionType/act> <https://spdx.org/rdf/3/terms/Security/SsvcDecisionType/attend> <https://spdx.org/rdf/3/terms/Security/SsvcDecisionType/track> <https://spdx.org/rdf/3/terms/Security/SsvcDecisionType/trackStar> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns4:decisionType ] .
+            sh:path ns5:decisionType ] .
 
-ns4:VexAffectedVulnAssessmentRelationship a owl:Class,
+ns5:VexAffectedVulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Connects a vulnerability and an element designating the element as a product
 affected by the vulnerability."""@en ;
-    rdfs:subClassOf ns4:VexVulnAssessmentRelationship ;
+    rdfs:subClassOf ns5:VexVulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:actionStatement ],
+            sh:path ns5:actionStatement ],
         [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:actionStatementTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ] .
+            sh:path ns5:actionStatementTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ] .
 
-ns4:VexFixedVulnAssessmentRelationship a owl:Class ;
+ns5:VexFixedVulnAssessmentRelationship a owl:Class ;
     rdfs:comment """Links a vulnerability and elements representing products (in the VEX sense) where
 a fix has been applied and are no longer affected."""@en ;
-    rdfs:subClassOf ns4:VexVulnAssessmentRelationship ;
+    rdfs:subClassOf ns5:VexVulnAssessmentRelationship ;
     sh:nodeKind sh:IRI .
 
-<https://spdx.org/rdf/3.1/terms/Security/VexJustificationType/componentNotPresent> a owl:NamedIndividual,
-        ns4:VexJustificationType ;
+<https://spdx.org/rdf/3/terms/Security/VexJustificationType/componentNotPresent> a owl:NamedIndividual,
+        ns5:VexJustificationType ;
     rdfs:label "componentNotPresent" ;
     rdfs:comment "The software is not affected because the vulnerable component is not in the product."@en .
 
-<https://spdx.org/rdf/3.1/terms/Security/VexJustificationType/inlineMitigationsAlreadyExist> a owl:NamedIndividual,
-        ns4:VexJustificationType ;
+<https://spdx.org/rdf/3/terms/Security/VexJustificationType/inlineMitigationsAlreadyExist> a owl:NamedIndividual,
+        ns5:VexJustificationType ;
     rdfs:label "inlineMitigationsAlreadyExist" ;
     rdfs:comment "Built-in inline controls or mitigations prevent an adversary from leveraging the vulnerability."@en .
 
-<https://spdx.org/rdf/3.1/terms/Security/VexJustificationType/vulnerableCodeCannotBeControlledByAdversary> a owl:NamedIndividual,
-        ns4:VexJustificationType ;
+<https://spdx.org/rdf/3/terms/Security/VexJustificationType/vulnerableCodeCannotBeControlledByAdversary> a owl:NamedIndividual,
+        ns5:VexJustificationType ;
     rdfs:label "vulnerableCodeCannotBeControlledByAdversary" ;
     rdfs:comment "The vulnerable component is present, and the component contains the vulnerable code. However, vulnerable code is used in such a way that an attacker cannot mount any anticipated attack."@en .
 
-<https://spdx.org/rdf/3.1/terms/Security/VexJustificationType/vulnerableCodeNotInExecutePath> a owl:NamedIndividual,
-        ns4:VexJustificationType ;
+<https://spdx.org/rdf/3/terms/Security/VexJustificationType/vulnerableCodeNotInExecutePath> a owl:NamedIndividual,
+        ns5:VexJustificationType ;
     rdfs:label "vulnerableCodeNotInExecutePath" ;
     rdfs:comment "The affected code is not reachable through the execution of the code, including non-anticipated states of the product."@en .
 
-<https://spdx.org/rdf/3.1/terms/Security/VexJustificationType/vulnerableCodeNotPresent> a owl:NamedIndividual,
-        ns4:VexJustificationType ;
+<https://spdx.org/rdf/3/terms/Security/VexJustificationType/vulnerableCodeNotPresent> a owl:NamedIndividual,
+        ns5:VexJustificationType ;
     rdfs:label "vulnerableCodeNotPresent" ;
     rdfs:comment "The product is not affected because the code underlying the vulnerability is not present in the product."@en .
 
-ns4:VexNotAffectedVulnAssessmentRelationship a owl:Class,
+ns5:VexNotAffectedVulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Links a vulnerability and one or more elements designating the latter as products
 not affected by the vulnerability."""@en ;
-    rdfs:subClassOf ns4:VexVulnAssessmentRelationship ;
+    rdfs:subClassOf ns5:VexVulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:string ;
+    sh:property [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:impactStatement ],
-        [ sh:class ns4:VexJustificationType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Security/VexJustificationType/componentNotPresent> <https://spdx.org/rdf/3.1/terms/Security/VexJustificationType/vulnerableCodeNotPresent> <https://spdx.org/rdf/3.1/terms/Security/VexJustificationType/vulnerableCodeCannotBeControlledByAdversary> <https://spdx.org/rdf/3.1/terms/Security/VexJustificationType/vulnerableCodeNotInExecutePath> <https://spdx.org/rdf/3.1/terms/Security/VexJustificationType/inlineMitigationsAlreadyExist> ) ;
+            sh:path ns5:impactStatementTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns5:impactStatement ],
+        [ sh:class ns5:VexJustificationType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Security/VexJustificationType/componentNotPresent> <https://spdx.org/rdf/3/terms/Security/VexJustificationType/vulnerableCodeNotPresent> <https://spdx.org/rdf/3/terms/Security/VexJustificationType/vulnerableCodeCannotBeControlledByAdversary> <https://spdx.org/rdf/3/terms/Security/VexJustificationType/vulnerableCodeNotInExecutePath> <https://spdx.org/rdf/3/terms/Security/VexJustificationType/inlineMitigationsAlreadyExist> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns4:justificationType ],
-        [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns4:impactStatementTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ] .
+            sh:path ns5:justificationType ] .
 
-ns4:VexUnderInvestigationVulnAssessmentRelationship a owl:Class ;
+ns5:VexUnderInvestigationVulnAssessmentRelationship a owl:Class ;
     rdfs:comment """Designates elements as products where the impact of a vulnerability is being
 investigated."""@en ;
-    rdfs:subClassOf ns4:VexVulnAssessmentRelationship ;
+    rdfs:subClassOf ns5:VexVulnAssessmentRelationship ;
     sh:nodeKind sh:IRI .
 
-ns4:Vulnerability a owl:Class,
+ns5:Vulnerability a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Specifies a vulnerability and its associated information."@en ;
     rdfs:subClassOf ns1:Artifact ;
@@ -2781,99 +2959,98 @@ ns4:Vulnerability a owl:Class,
     sh:property [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:withdrawnTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+            sh:path ns5:modifiedTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
         [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:publishedTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+            sh:path ns5:publishedTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
         [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:modifiedTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ] .
+            sh:path ns5:withdrawnTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ] .
 
-ns4:actionStatement a owl:DatatypeProperty ;
+ns5:actionStatement a owl:DatatypeProperty ;
     rdfs:comment """Provides advise on how to mitigate or remediate a vulnerability when a VEX product
 is affected by it."""@en ;
     rdfs:range xsd:string .
 
-ns4:actionStatementTime a owl:DatatypeProperty ;
+ns5:actionStatementTime a owl:DatatypeProperty ;
     rdfs:comment """Records the time when a recommended action was communicated in a VEX statement
 to mitigate a vulnerability."""@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns4:assessedElement a owl:ObjectProperty ;
-    rdfs:comment """Specifies an Element contained in a piece of software where a vulnerability was
-found."""@en ;
-    rdfs:range ns6:SoftwareArtifact .
+ns5:assessedElement a owl:ObjectProperty ;
+    rdfs:comment "Specifies an Element where a vulnerability was found."@en ;
+    rdfs:range ns1:Artifact .
 
-ns4:catalogType a owl:ObjectProperty ;
+ns5:catalogType a owl:ObjectProperty ;
     rdfs:comment "Specifies the exploit catalog type."@en ;
-    rdfs:range ns4:ExploitCatalogType .
+    rdfs:range ns5:ExploitCatalogType .
 
-ns4:decisionType a owl:ObjectProperty ;
+ns5:decisionType a owl:ObjectProperty ;
     rdfs:comment """Provide the enumeration of possible decisions in the
 [Stakeholder-Specific Vulnerability Categorization (SSVC) decision tree](https://www.cisa.gov/stakeholder-specific-vulnerability-categorization-ssvc)."""@en ;
-    rdfs:range ns4:SsvcDecisionType .
+    rdfs:range ns5:SsvcDecisionType .
 
-ns4:exploited a owl:DatatypeProperty ;
+ns5:exploited a owl:DatatypeProperty ;
     rdfs:comment "Denote whether a CVE is present in an exploit catalog."@en ;
     rdfs:range xsd:boolean .
 
-ns4:impactStatement a owl:DatatypeProperty ;
+ns5:impactStatement a owl:DatatypeProperty ;
     rdfs:comment """Explains why a VEX product is not affected by a vulnerability. It is an
 alternative in VexNotAffectedVulnAssessmentRelationship to the machine-readable
 justification label."""@en ;
     rdfs:range xsd:string .
 
-ns4:impactStatementTime a owl:DatatypeProperty ;
+ns5:impactStatementTime a owl:DatatypeProperty ;
     rdfs:comment "Timestamp of impact statement."@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns4:justificationType a owl:ObjectProperty ;
+ns5:justificationType a owl:ObjectProperty ;
     rdfs:comment """Impact justification label to be used when linking a vulnerability to an element
 representing a VEX product with a VexNotAffectedVulnAssessmentRelationship
 relationship."""@en ;
-    rdfs:range ns4:VexJustificationType .
+    rdfs:range ns5:VexJustificationType .
 
-ns4:locator a owl:DatatypeProperty ;
+ns5:locator a owl:DatatypeProperty ;
     rdfs:comment "Provides the location of an exploit catalog."@en ;
     rdfs:range xsd:anyURI .
 
-ns4:percentile a owl:DatatypeProperty ;
+ns5:percentile a owl:DatatypeProperty ;
     rdfs:comment "The percentile of the current probability score."@en ;
     rdfs:range xsd:decimal .
 
-ns4:probability a owl:DatatypeProperty ;
+ns5:probability a owl:DatatypeProperty ;
     rdfs:comment "A probability score between 0 and 1 of a vulnerability being exploited."@en ;
     rdfs:range xsd:decimal .
 
-ns4:statusNotes a owl:DatatypeProperty ;
+ns5:statusNotes a owl:DatatypeProperty ;
     rdfs:comment "Conveys information about how VEX status was determined."@en ;
     rdfs:range xsd:string .
 
-ns4:vexVersion a owl:DatatypeProperty ;
+ns5:vexVersion a owl:DatatypeProperty ;
     rdfs:comment "Specifies the version of a VEX statement."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/Service/AuthenticationProtocolType/crl> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Service/AuthenticationProtocolType/crl> a owl:NamedIndividual,
         ns8:AuthenticationProtocolType ;
     rdfs:label "crl" ;
     rdfs:comment "Certificate Revocation List, or CRL, is a list of revoked certificates that is downloaded from the Certificate Authority (CA)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Service/AuthenticationProtocolType/ocsp> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Service/AuthenticationProtocolType/ocsp> a owl:NamedIndividual,
         ns8:AuthenticationProtocolType ;
     rdfs:label "ocsp" ;
     rdfs:comment "Online Certificate Status Protocol, or OCSP, is a common scheme used to maintain the security of a server and other network resources."@en .
 
-<https://spdx.org/rdf/3.1/terms/Service/AuthenticationProtocolType/other> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Service/AuthenticationProtocolType/other> a owl:NamedIndividual,
         ns8:AuthenticationProtocolType ;
     rdfs:label "other" ;
     rdfs:comment "An authentication protocol not covered by one of the other AuthenticationProtocolTypes."@en .
 
-<https://spdx.org/rdf/3.1/terms/Service/AuthenticationProtocolType/tls> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Service/AuthenticationProtocolType/tls> a owl:NamedIndividual,
         ns8:AuthenticationProtocolType ;
     rdfs:label "tls" ;
     rdfs:comment "Transport Layer Security, or TLS, is a widely adopted security protocol designed to facilitate privacy and data security for communications over the Internet."@en .
@@ -2881,24 +3058,16 @@ ns4:vexVersion a owl:DatatypeProperty ;
 ns8:SoftwareService a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Software provided as a service over a network."@en ;
-    rdfs:subClassOf ns1:Element ;
+    rdfs:subClassOf ns1:Artifact ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns8:AuthenticationProtocolType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Service/AuthenticationProtocolType/tls> <https://spdx.org/rdf/3.1/terms/Service/AuthenticationProtocolType/ocsp> <https://spdx.org/rdf/3.1/terms/Service/AuthenticationProtocolType/crl> <https://spdx.org/rdf/3.1/terms/Service/AuthenticationProtocolType/other> ) ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns8:serverAuthenticationProtocol ],
-        [ sh:class ns1:Agent ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns8:provider ],
-        [ sh:datatype xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:path ns8:serviceHostingCountry ;
-            sh:pattern "^[A-Z]{3}$" ] .
-
-ns8:provider a owl:ObjectProperty ;
-    rdfs:comment "The provider of a SoftwareService."@en ;
-    rdfs:range ns1:Agent .
+            sh:pattern "^[A-Z]{3}$" ],
+        [ sh:class ns8:AuthenticationProtocolType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Service/AuthenticationProtocolType/tls> <https://spdx.org/rdf/3/terms/Service/AuthenticationProtocolType/ocsp> <https://spdx.org/rdf/3/terms/Service/AuthenticationProtocolType/crl> <https://spdx.org/rdf/3/terms/Service/AuthenticationProtocolType/other> ) ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns8:serverAuthenticationProtocol ] .
 
 ns8:serverAuthenticationProtocol a owl:ObjectProperty ;
     rdfs:comment "Authentication protocol used by a server."@en ;
@@ -2908,29 +3077,29 @@ ns8:serviceHostingCountry a owl:DatatypeProperty ;
     rdfs:comment "Specifies a country code where a software service is hosted."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/SimpleLicensing/LicenseExpression> a owl:Class,
+<https://spdx.org/rdf/3/terms/SimpleLicensing/LicenseExpression> a owl:Class,
         sh:NodeShape ;
     rdfs:comment "An SPDX Element containing an SPDX license expression string."@en ;
-    rdfs:subClassOf <https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo> ;
+    rdfs:subClassOf <https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo> ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:ElementMap ;
+    sh:property [ sh:class ns1:DictionaryEntry ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path <https://spdx.org/rdf/3.1/terms/SimpleLicensing/customIdToLicense> ],
+            sh:path <https://spdx.org/rdf/3/terms/SimpleLicensing/customIdToUri> ],
+        [ sh:class ns1:ElementMap ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <https://spdx.org/rdf/3/terms/SimpleLicensing/customIdToLicense> ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path <https://spdx.org/rdf/3/terms/SimpleLicensing/licenseListVersion> ;
+            sh:pattern "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))?$" ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/SimpleLicensing/licenseExpression> ],
-        [ sh:class ns1:DictionaryEntry ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path <https://spdx.org/rdf/3.1/terms/SimpleLicensing/customIdToUri> ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/SimpleLicensing/licenseListVersion> ;
-            sh:pattern "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$" ] .
+            sh:path <https://spdx.org/rdf/3/terms/SimpleLicensing/licenseExpression> ] .
 
-<https://spdx.org/rdf/3.1/terms/SimpleLicensing/SimpleLicensingText> a owl:Class,
+<https://spdx.org/rdf/3/terms/SimpleLicensing/SimpleLicensingText> a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A license or addition that is not listed on the SPDX License List."@en ;
     rdfs:subClassOf ns1:Element ;
@@ -2939,15 +3108,15 @@ ns8:serviceHostingCountry a owl:DatatypeProperty ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/SimpleLicensing/licenseText> ] .
+            sh:path <https://spdx.org/rdf/3/terms/SimpleLicensing/licenseText> ] .
 
-<https://spdx.org/rdf/3.1/terms/SimpleLicensing/customIdToLicense> a owl:ObjectProperty ;
+<https://spdx.org/rdf/3/terms/SimpleLicensing/customIdToLicense> a owl:ObjectProperty ;
     rdfs:comment """Maps a "LicenseRef-" string for a custom license or a "AdditionRef-" string for
 a custom license addition to a `CustomLicense`, a `CustomLicenseAddition`, or a
 `SimpleLicensingText`."""@en ;
     rdfs:range ns1:ElementMap .
 
-<https://spdx.org/rdf/3.1/terms/SimpleLicensing/customIdToUri> a owl:ObjectProperty ;
+<https://spdx.org/rdf/3/terms/SimpleLicensing/customIdToUri> a owl:ObjectProperty ;
     rdfs:comment """**DEPRECATED in SPDX 3.1.**
 Use [customIdToLicense](./customIdToLicense.md) instead.
 
@@ -2959,190 +3128,198 @@ This property is deprecated and only included for backward compatibility.
 New documents should use [customIdToLicense](./customIdToLicense.md) instead."""@en ;
     rdfs:range ns1:DictionaryEntry .
 
-<https://spdx.org/rdf/3.1/terms/SimpleLicensing/licenseExpression> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/SimpleLicensing/licenseExpression> a owl:DatatypeProperty ;
     rdfs:comment "A string in the license expression format."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/SimpleLicensing/licenseListVersion> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/SimpleLicensing/licenseListVersion> a owl:DatatypeProperty ;
     rdfs:comment "The version of the SPDX License List used in the license expression."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/Software/ContentIdentifierType/gitoid> a owl:NamedIndividual,
-        ns6:ContentIdentifierType ;
+<https://spdx.org/rdf/3/terms/Software/ContentIdentifierType/gitoid> a owl:NamedIndividual,
+        ns4:ContentIdentifierType ;
     rdfs:label "gitoid" ;
     rdfs:comment "[Gitoid](https://www.iana.org/assignments/uri-schemes/prov/gitoid), stands for [Git Object ID](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects). A gitoid of type blob is a unique hash of a binary artifact. A gitoid may represent either an [Artifact Identifier](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#artifact-identifier-types) for the software artifact or an [Input Manifest Identifier](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#input-manifest-identifier) for the software artifact's associated [Artifact Input Manifest](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#artifact-input-manifest); this ambiguity exists because the Artifact Input Manifest is itself an artifact, and the gitoid of that artifact is its valid identifier. Gitoids calculated on software artifacts (Snippet, File, or Package Elements) should be recorded in the SPDX 3 SoftwareArtifact's contentIdentifier property. Gitoids calculated on the Artifact Input Manifest (Input Manifest Identifier) should be recorded in the SPDX 3 Element's externalIdentifier property. See [OmniBOR Specification](https://github.com/omnibor/spec/), a minimalistic specification for describing software [Artifact Dependency Graphs](https://github.com/omnibor/spec/blob/eb1ee5c961c16215eb8709b2975d193a2007a35d/spec/SPEC.md#artifact-dependency-graph-adg)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/ContentIdentifierType/swhid> a owl:NamedIndividual,
-        ns6:ContentIdentifierType ;
+<https://spdx.org/rdf/3/terms/Software/ContentIdentifierType/swhid> a owl:NamedIndividual,
+        ns4:ContentIdentifierType ;
     rdfs:label "swhid" ;
     rdfs:comment "SoftWare Hash IDentifier, a persistent intrinsic identifier for digital artifacts, such as files, trees (also known as directories or folders), commits, and other objects typically found in version control systems. The format of the identifiers is defined in the [SWHID specification](https://www.swhid.org/swhid-specification/v1.2/) ([ISO/IEC 18670](https://www.iso.org/standard/89985.html)). They typically look like `swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2`."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/FileKindType/directory> a owl:NamedIndividual,
-        ns6:FileKindType ;
+<https://spdx.org/rdf/3/terms/Software/FileKindType/directory> a owl:NamedIndividual,
+        ns4:FileKindType ;
     rdfs:label "directory" ;
     rdfs:comment "The file represents a directory and all content stored in that directory."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/FileKindType/file> a owl:NamedIndividual,
-        ns6:FileKindType ;
+<https://spdx.org/rdf/3/terms/Software/FileKindType/file> a owl:NamedIndividual,
+        ns4:FileKindType ;
     rdfs:label "file" ;
     rdfs:comment "The file represents a single file (default)."@en .
 
-ns6:Sbom a owl:Class,
+<https://spdx.org/rdf/3/terms/Software/FileKindType/symlink> a owl:NamedIndividual,
+        ns4:FileKindType ;
+    rdfs:label "symlink" ;
+    rdfs:comment "This file represents a symbolic link (soft link)."@en .
+
+ns4:Sbom a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A collection of SPDX Elements describing a single package."@en ;
     rdfs:subClassOf ns1:Bom ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns6:SbomType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Software/SbomType/design> <https://spdx.org/rdf/3.1/terms/Software/SbomType/source> <https://spdx.org/rdf/3.1/terms/Software/SbomType/build> <https://spdx.org/rdf/3.1/terms/Software/SbomType/deployed> <https://spdx.org/rdf/3.1/terms/Software/SbomType/runtime> <https://spdx.org/rdf/3.1/terms/Software/SbomType/analyzed> ) ;
+    sh:property [ sh:class ns4:SbomType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Software/SbomType/design> <https://spdx.org/rdf/3/terms/Software/SbomType/source> <https://spdx.org/rdf/3/terms/Software/SbomType/build> <https://spdx.org/rdf/3/terms/Software/SbomType/deployed> <https://spdx.org/rdf/3/terms/Software/SbomType/runtime> <https://spdx.org/rdf/3/terms/Software/SbomType/analyzed> ) ;
             sh:nodeKind sh:IRI ;
-            sh:path ns6:sbomType ] .
+            sh:path ns4:sbomType ] .
 
-<https://spdx.org/rdf/3.1/terms/Software/SbomType/analyzed> a owl:NamedIndividual,
-        ns6:SbomType ;
+<https://spdx.org/rdf/3/terms/Software/SbomType/analyzed> a owl:NamedIndividual,
+        ns4:SbomType ;
     rdfs:label "analyzed" ;
     rdfs:comment "SBOM generated through analysis of artifacts (e.g., executables, packages, containers, and virtual machine images) after its build. Such analysis generally requires a variety of heuristics. In some contexts, this may also be referred to as a \"3rd party\" SBOM."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SbomType/build> a owl:NamedIndividual,
-        ns6:SbomType ;
+<https://spdx.org/rdf/3/terms/Software/SbomType/build> a owl:NamedIndividual,
+        ns4:SbomType ;
     rdfs:label "build" ;
     rdfs:comment "SBOM generated as part of the process of building the software to create a releasable artifact (e.g., executable or package) from data such as source files, dependencies, built components, build process ephemeral data, and other SBOMs."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SbomType/deployed> a owl:NamedIndividual,
-        ns6:SbomType ;
+<https://spdx.org/rdf/3/terms/Software/SbomType/deployed> a owl:NamedIndividual,
+        ns4:SbomType ;
     rdfs:label "deployed" ;
     rdfs:comment "SBOM provides an inventory of software that is present on a system. This may be an assembly of other SBOMs that combines analysis of configuration options, and examination of execution behavior in a (potentially simulated) deployment environment."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SbomType/design> a owl:NamedIndividual,
-        ns6:SbomType ;
+<https://spdx.org/rdf/3/terms/Software/SbomType/design> a owl:NamedIndividual,
+        ns4:SbomType ;
     rdfs:label "design" ;
     rdfs:comment "SBOM of intended, planned software project or product with included components (some of which may not yet exist) for a new software artifact."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SbomType/runtime> a owl:NamedIndividual,
-        ns6:SbomType ;
+<https://spdx.org/rdf/3/terms/Software/SbomType/runtime> a owl:NamedIndividual,
+        ns4:SbomType ;
     rdfs:label "runtime" ;
     rdfs:comment "SBOM generated through instrumenting the system running the software, to capture only components present in the system, as well as external call-outs or dynamically loaded components. In some contexts, this may also be referred to as an \"Instrumented\" or \"Dynamic\" SBOM."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SbomType/source> a owl:NamedIndividual,
-        ns6:SbomType ;
+<https://spdx.org/rdf/3/terms/Software/SbomType/source> a owl:NamedIndividual,
+        ns4:SbomType ;
     rdfs:label "source" ;
     rdfs:comment "SBOM created directly from the development environment, source files, and included dependencies used to build a product artifact."@en .
 
-ns6:Snippet a owl:Class,
+ns4:Snippet a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Describes a certain part of a file."@en ;
-    rdfs:subClassOf ns6:SoftwareArtifact ;
+    rdfs:subClassOf ns4:SoftwareArtifact ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns6:File ;
+    sh:property [ sh:class ns1:PositiveIntegerRange ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns4:byteRange ],
+        [ sh:class ns4:File ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns6:snippetFromFile ],
+            sh:path ns4:snippetFromFile ],
         [ sh:class ns1:PositiveIntegerRange ;
             sh:maxCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns6:lineRange ],
-        [ sh:class ns1:PositiveIntegerRange ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns6:byteRange ] .
+            sh:path ns4:lineRange ] .
 
-ns6:additionalPurpose a owl:ObjectProperty ;
+ns4:additionalPurpose a owl:ObjectProperty ;
     rdfs:comment "Provides additional purpose information of the software artifact."@en ;
-    rdfs:range ns6:SoftwarePurpose .
+    rdfs:range ns4:SoftwarePurpose .
 
-ns6:artifactSize a owl:DatatypeProperty ;
+ns4:artifactSize a owl:DatatypeProperty ;
     rdfs:comment "Identifies the size of a software Artifact, in bytes."@en ;
     rdfs:range xsd:nonNegativeInteger .
 
-ns6:attributionText a owl:DatatypeProperty ;
+ns4:attributionText a owl:DatatypeProperty ;
     rdfs:comment """Provides a place for the SPDX data creator to record acknowledgement text for
 a software Package, File or Snippet."""@en ;
     rdfs:range xsd:string .
 
-ns6:byteRange a owl:DatatypeProperty ;
+ns4:byteRange a owl:DatatypeProperty ;
     rdfs:comment """Defines the byte range in the original host file that the snippet information
 applies to."""@en ;
     rdfs:range ns1:PositiveIntegerRange .
 
-ns6:contentIdentifier a owl:DatatypeProperty ;
+ns4:contentIdentifier a owl:DatatypeProperty ;
     rdfs:comment """A canonical, unique, immutable identifier of the artifact content, that may be
 used for verifying its identity and/or integrity."""@en ;
-    rdfs:range ns6:ContentIdentifier .
+    rdfs:range ns4:ContentIdentifier .
 
-ns6:contentIdentifierType a owl:ObjectProperty ;
+ns4:contentIdentifierType a owl:ObjectProperty ;
     rdfs:comment "Specifies the type of the content identifier."@en ;
-    rdfs:range ns6:ContentIdentifierType .
+    rdfs:range ns4:ContentIdentifierType .
 
-ns6:contentIdentifierValue a owl:DatatypeProperty ;
+ns4:contentIdentifierValue a owl:DatatypeProperty ;
     rdfs:comment "Specifies the value of the content identifier."@en ;
     rdfs:range xsd:anyURI .
 
-ns6:copyrightText a owl:DatatypeProperty ;
+ns4:copyrightText a owl:DatatypeProperty ;
     rdfs:comment """Identifies the text of one or more copyright notices for a software Package,
 File or Snippet, if any."""@en ;
     rdfs:range xsd:string .
 
-ns6:downloadLocation a owl:DatatypeProperty ;
+ns4:downloadLocation a owl:DatatypeProperty ;
     rdfs:comment """Identifies the download Uniform Resource Identifier for the package at the time
 that the document was created."""@en ;
     rdfs:range xsd:anyURI .
 
-ns6:fileKind a owl:ObjectProperty ;
+ns4:fileKind a owl:ObjectProperty ;
     rdfs:comment "Describes if a given file is a directory or non-directory kind of file."@en ;
-    rdfs:range ns6:FileKindType .
+    rdfs:range ns4:FileKindType .
 
-ns6:homePage a owl:DatatypeProperty ;
+ns4:homePage a owl:DatatypeProperty ;
     rdfs:comment """A place for the SPDX document creator to record a website that serves as the
 package's home page."""@en ;
     rdfs:range xsd:anyURI .
 
-ns6:lineRange a owl:DatatypeProperty ;
+ns4:lineRange a owl:DatatypeProperty ;
     rdfs:comment """Defines the line range in the original host file that the snippet information
 applies to."""@en ;
     rdfs:range ns1:PositiveIntegerRange .
 
-ns6:packageUrl a owl:DatatypeProperty ;
-    rdfs:comment """Provides a place for the SPDX data creator to record the package URL string
-(in accordance with the Package URL specification) for a software Package."""@en ;
+ns4:packageUrl a owl:DatatypeProperty ;
+    rdfs:comment """Provides a place for the SPDX data creator to record the Package-URL
+for a software Package."""@en ;
     rdfs:range xsd:anyURI .
 
-ns6:packageVersion a owl:DatatypeProperty ;
-    rdfs:comment "Identify the version of a package."@en ;
+ns4:packageVersion a owl:DatatypeProperty ;
+    rdfs:comment """**DEPRECATED in SPDX 3.1.**
+Use [/Core/version](../../Core/Properties/version.md) instead.
+
+Identify the version of a package."""@en ;
     rdfs:range xsd:string .
 
-ns6:primaryPurpose a owl:ObjectProperty ;
+ns4:primaryPurpose a owl:ObjectProperty ;
     rdfs:comment "Provides information about the primary purpose of the software artifact."@en ;
-    rdfs:range ns6:SoftwarePurpose .
+    rdfs:range ns4:SoftwarePurpose .
 
-ns6:sbomType a owl:ObjectProperty ;
+ns4:sbomType a owl:ObjectProperty ;
     rdfs:comment "Provides information about the type of an SBOM."@en ;
-    rdfs:range ns6:SbomType .
+    rdfs:range ns4:SbomType .
 
-ns6:snippetFromFile a owl:ObjectProperty ;
+ns4:snippetFromFile a owl:ObjectProperty ;
     rdfs:comment "Defines the original host file that the snippet information applies to."@en ;
-    rdfs:range ns6:File .
+    rdfs:range ns4:File .
 
-ns6:sourceInfo a owl:DatatypeProperty ;
+ns4:sourceInfo a owl:DatatypeProperty ;
     rdfs:comment """Records any relevant background information or additional comments
 about the origin of the package."""@en ;
     rdfs:range xsd:string .
 
-ns7:AssemblyAction a owl:Class ;
+ns9:AssemblyAction a owl:Class ;
     rdfs:comment "AssemblyAction represents the event of creating a product by assembling individual components."@en ;
-    rdfs:subClassOf ns7:CreateAction ;
+    rdfs:subClassOf ns9:CreateAction ;
     sh:nodeKind sh:IRI .
 
-ns7:AssemblyProcess a owl:Class ;
+ns9:AssemblyProcess a owl:Class ;
     rdfs:comment "The AssemblyProcess represents the process of creating a product by assembling a set of components, potentially in a way that allows for at disassembly (at least partially)."@en ;
-    rdfs:subClassOf ns7:CreateProcess ;
+    rdfs:subClassOf ns9:CreateProcess ;
     sh:nodeKind sh:IRI .
 
-ns7:BoundaryCrossingAction a owl:Class ;
+ns9:BoundaryCrossingAction a owl:Class ;
     rdfs:comment "An action of crossing a boundary is defined in this class."@en ;
-    rdfs:subClassOf ns7:UseAction ;
+    rdfs:subClassOf ns9:UseAction ;
     sh:nodeKind sh:IRI .
 
-ns7:BoundaryDefinitionAction a owl:Class,
+ns9:BoundaryDefinitionAction a owl:Class,
         sh:NodeShape ;
     rdfs:comment "The boundary definition is used to define boundaries."@en ;
     rdfs:subClassOf ns1:Action ;
@@ -3150,24 +3327,24 @@ ns7:BoundaryDefinitionAction a owl:Class,
     sh:property [ sh:class ns1:DictionaryEntry ;
             sh:minCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns7:boundaryParameter ] .
+            sh:path ns9:boundaryParameter ] .
 
-ns7:BoundaryDefinitionProcess a owl:Class ;
+ns9:BoundaryDefinitionProcess a owl:Class ;
     rdfs:comment "The Boundary Definition Process refers to the process class used to produce boundaries."@en ;
     rdfs:subClassOf ns1:DefinedProcess ;
     sh:nodeKind sh:IRI .
 
-ns7:ChangeAction a owl:Class ;
+ns9:ChangeAction a owl:Class ;
     rdfs:comment "An actual change to a product."@en ;
-    rdfs:subClassOf ns7:ModifyAction ;
+    rdfs:subClassOf ns9:ModifyAction ;
     sh:nodeKind sh:IRI .
 
-ns7:ChangeProcess a owl:Class ;
+ns9:ChangeProcess a owl:Class ;
     rdfs:comment "A prescribed change to a product."@en ;
-    rdfs:subClassOf ns7:ModifyProcess ;
+    rdfs:subClassOf ns9:ModifyProcess ;
     sh:nodeKind sh:IRI .
 
-ns7:DestroyAction a owl:Class,
+ns9:DestroyAction a owl:Class,
         sh:NodeShape ;
     rdfs:comment "The record of destruction is entered in this action."@en ;
     rdfs:subClassOf ns1:Action ;
@@ -3175,83 +3352,83 @@ ns7:DestroyAction a owl:Class,
     sh:property [ sh:class ns1:Agent ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns7:destructionPerformedBy ] .
+            sh:path ns9:destructionPerformedBy ] .
 
-ns7:DestroyProcess a owl:Class ;
+ns9:DestroyProcess a owl:Class ;
     rdfs:comment "The destruction process is defined in this process."@en ;
     rdfs:subClassOf ns1:DefinedProcess ;
     sh:nodeKind sh:IRI .
 
-ns7:HarvestAction a owl:Class ;
+ns9:HarvestAction a owl:Class ;
     rdfs:comment "HarvestAction represents the act of creating a product by directly extracting goods or materials from nature."@en ;
-    rdfs:subClassOf ns7:CreateAction ;
+    rdfs:subClassOf ns9:CreateAction ;
     sh:nodeKind sh:IRI .
 
-ns7:HarvestProcess a owl:Class ;
+ns9:HarvestProcess a owl:Class ;
     rdfs:comment "Harvest is the process of extracting goods or products from nature."@en ;
-    rdfs:subClassOf ns7:CreateProcess ;
+    rdfs:subClassOf ns9:CreateProcess ;
     sh:nodeKind sh:IRI .
 
-ns7:InspectionAction a owl:Class ;
+ns9:InspectionAction a owl:Class ;
     rdfs:comment "An inspection action refers to a specific activity or set of activities performed during an inspection to examine, verify, or evaluate an item, process, or system."@en ;
-    rdfs:subClassOf ns7:UseAction ;
+    rdfs:subClassOf ns9:UseAction ;
     sh:nodeKind sh:IRI .
 
-ns7:InspectionProcess a owl:Class,
+ns9:InspectionProcess a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Inspection Process defines specific various processes needed to satisfy the inspection requirements for a specific product or service."@en ;
-    rdfs:subClassOf ns7:UseProcess ;
+    rdfs:subClassOf ns9:UseProcess ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:class ns1:Location ;
             sh:nodeKind sh:IRI ;
-            sh:path ns7:plannedInspectionLocation ] .
+            sh:path ns9:plannedInspectionLocation ] .
 
-ns7:InstantiateVirtualHardwareProcess a owl:Class ;
+ns9:InstantiateVirtualHardwareProcess a owl:Class ;
     rdfs:comment "Class that describes an InstantiateVirtualHardwareProcess that is used to define VirtualHardware and its source."@en ;
-    rdfs:subClassOf ns7:CreateProcess ;
+    rdfs:subClassOf ns9:CreateProcess ;
     sh:nodeKind sh:IRI .
 
-ns7:ManufactureAction a owl:Class ;
+ns9:ManufactureAction a owl:Class ;
     rdfs:comment "ManufactureAction represents the act of creating a product by a manufacturing process."@en ;
-    rdfs:subClassOf ns7:CreateAction ;
+    rdfs:subClassOf ns9:CreateAction ;
     sh:nodeKind sh:IRI .
 
-ns7:ManufactureProcess a owl:Class ;
+ns9:ManufactureProcess a owl:Class ;
     rdfs:comment "This class represents the process involved in manufacturing products."@en ;
-    rdfs:subClassOf ns7:CreateProcess ;
+    rdfs:subClassOf ns9:CreateProcess ;
     sh:nodeKind sh:IRI .
 
-ns7:OutOfSpecAction a owl:Class ;
+ns9:OutOfSpecAction a owl:Class ;
     rdfs:comment "An out of specification action is defined in this class."@en ;
-    rdfs:subClassOf ns7:UseAction ;
+    rdfs:subClassOf ns9:UseAction ;
     sh:nodeKind sh:IRI .
 
-ns7:PlanAction a owl:Class ;
+ns9:PlanAction a owl:Class ;
     rdfs:comment "A PlanAction involves the execution of a plan in relation to a PlanProcess."@en ;
-    rdfs:subClassOf ns7:UseAction ;
+    rdfs:subClassOf ns9:UseAction ;
     sh:nodeKind sh:IRI .
 
-ns7:PlanProcess a owl:Class ;
+ns9:PlanProcess a owl:Class ;
     rdfs:comment "Process plans outline the stages of implementation or use related to a process."@en ;
-    rdfs:subClassOf ns7:UseProcess ;
+    rdfs:subClassOf ns9:UseProcess ;
     sh:nodeKind sh:IRI .
 
-ns7:ReproduceAction a owl:Class ;
+ns9:ReproduceAction a owl:Class ;
     rdfs:comment "Reproduction is the biological process by which organisms generate new individuals of the same species."@en ;
-    rdfs:subClassOf ns7:CreateAction ;
+    rdfs:subClassOf ns9:CreateAction ;
     sh:nodeKind sh:IRI .
 
-ns7:ReproduceProcess a owl:Class ;
+ns9:ReproduceProcess a owl:Class ;
     rdfs:comment "Reproduction is the biological process by which living organisms produce offspring."@en ;
-    rdfs:subClassOf ns7:CreateProcess ;
+    rdfs:subClassOf ns9:CreateProcess ;
     sh:nodeKind sh:IRI .
 
-ns7:ResolutionAction a owl:Class ;
+ns9:ResolutionAction a owl:Class ;
     rdfs:comment "Products out of specification require a resolution action. This is the action of resolution."@en ;
-    rdfs:subClassOf ns7:UseAction ;
+    rdfs:subClassOf ns9:UseAction ;
     sh:nodeKind sh:IRI .
 
-ns7:ResponsibilityChangeAction a owl:Class,
+ns9:ResponsibilityChangeAction a owl:Class,
         sh:NodeShape ;
     rdfs:comment "ResponsibilityChangeAction refers to the transfer of responsibility from one party to another."@en ;
     rdfs:subClassOf ns1:Action ;
@@ -3260,191 +3437,192 @@ ns7:ResponsibilityChangeAction a owl:Class,
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns7:current ],
+            sh:path ns9:current ],
+        [ sh:class ns9:ResponsibilityType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/SupplyChain/ResponsibilityType/ownership> <https://spdx.org/rdf/3/terms/SupplyChain/ResponsibilityType/custody> ) ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns9:responsibilityCategory ],
         [ sh:class ns1:Element ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns7:responsibilityChangedOn ],
+            sh:path ns9:responsibilityChangedOn ],
         [ sh:class ns1:Agent ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns7:previous ],
-        [ sh:class ns7:ResponsibilityType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/SupplyChain/ResponsibilityType/ownership> <https://spdx.org/rdf/3.1/terms/SupplyChain/ResponsibilityType/custody> ) ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns7:responsibilityCategory ] .
+            sh:path ns9:previous ] .
 
-ns7:ResponsibilityChangeProcess a owl:Class,
+ns9:ResponsibilityChangeProcess a owl:Class,
         sh:NodeShape ;
     rdfs:comment "ResponsibilityChangeProcess refers to the process of transferring responsibility from one party to another."@en ;
     rdfs:subClassOf ns1:DefinedProcess ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns7:ResponsibilityType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/SupplyChain/ResponsibilityType/ownership> <https://spdx.org/rdf/3.1/terms/SupplyChain/ResponsibilityType/custody> ) ;
+    sh:property [ sh:class ns1:Element ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns9:plannedProductOfResponsibilityChange ],
+        [ sh:class ns1:Agent ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns9:plannedCurrent ],
+        [ sh:class ns1:Agent ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns9:plannedPrevious ],
+        [ sh:class ns9:ResponsibilityType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/SupplyChain/ResponsibilityType/ownership> <https://spdx.org/rdf/3/terms/SupplyChain/ResponsibilityType/custody> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns7:responsibilityCategory ],
-        [ sh:class ns1:Agent ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns7:plannedCurrent ],
-        [ sh:class ns1:Element ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns7:plannedProductOfResponsibilityChange ],
-        [ sh:class ns1:Agent ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns7:plannedPrevious ] .
+            sh:path ns9:responsibilityCategory ] .
 
-ns7:StateAction a owl:Class,
+ns9:StateAction a owl:Class,
         sh:NodeShape ;
     rdfs:comment "This is the state of an affected Element at a specific moment in time."@en ;
-    rdfs:subClassOf ns7:UseAction ;
+    rdfs:subClassOf ns9:UseAction ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns7:State ;
+    sh:property [ sh:class ns9:DefinedStateProcess ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns7:currentState ],
-        [ sh:class ns7:DefinedStateProcess ;
+            sh:path ns9:decisionProcess ],
+        [ sh:class ns9:State ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns7:decisionProcess ] .
+            sh:path ns9:currentState ] .
 
-ns7:StorageAction a owl:Class ;
+ns9:StorageAction a owl:Class ;
     rdfs:comment "Records the storage of a product."@en ;
-    rdfs:subClassOf ns7:ModifyAction ;
+    rdfs:subClassOf ns9:ModifyAction ;
     sh:nodeKind sh:IRI .
 
-ns7:StorageProcess a owl:Class,
+ns9:StorageProcess a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Prescribes the storage of a product."@en ;
-    rdfs:subClassOf ns7:ModifyProcess ;
+    rdfs:subClassOf ns9:ModifyProcess ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:class ns1:Location ;
             sh:nodeKind sh:IRI ;
-            sh:path ns7:plannedStorageLocation ] .
+            sh:path ns9:plannedStorageLocation ] .
 
-ns7:TestAction a owl:Class ;
+ns9:TestAction a owl:Class ;
     rdfs:comment "A test action is a specific action associated with a test."@en ;
-    rdfs:subClassOf ns7:UseAction ;
+    rdfs:subClassOf ns9:UseAction ;
     sh:nodeKind sh:IRI .
 
-ns7:TestProcess a owl:Class ;
+ns9:TestProcess a owl:Class ;
     rdfs:comment "Test Process defines the testing process for an element."@en ;
-    rdfs:subClassOf ns7:UseProcess ;
+    rdfs:subClassOf ns9:UseProcess ;
     sh:nodeKind sh:IRI .
 
-ns7:TransportAction a owl:Class,
+ns9:TransportAction a owl:Class,
         sh:NodeShape ;
     rdfs:comment "An actual change to a product's location."@en ;
-    rdfs:subClassOf ns7:ModifyAction ;
+    rdfs:subClassOf ns9:ModifyAction ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:class ns1:Location ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns7:pickupLocation ],
-        [ sh:class ns1:Location ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns7:dropoffLocation ],
+            sh:path ns9:pickupLocation ],
         [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:path ns7:transportRoute ] .
+            sh:path ns9:transportRoute ],
+        [ sh:class ns1:Location ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns9:dropoffLocation ] .
 
-ns7:TransportProcess a owl:Class,
+ns9:TransportProcess a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A prescribed change to a product's location."@en ;
-    rdfs:subClassOf ns7:ModifyProcess ;
+    rdfs:subClassOf ns9:ModifyProcess ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:Location ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns7:forPickupLocation ],
-        [ sh:datatype xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:path ns7:plannedTransportRoutes ],
+            sh:path ns9:plannedTransportRoute ],
         [ sh:class ns1:Location ;
             sh:nodeKind sh:IRI ;
-            sh:path ns7:forDropoffLocation ] .
+            sh:path ns9:forPickupLocation ],
+        [ sh:class ns1:Location ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns9:forDropoffLocation ] .
 
-ns7:boundaryParameter a owl:ObjectProperty ;
+ns9:boundaryParameter a owl:ObjectProperty ;
     rdfs:comment "The boundary parameters define the area or region needed to describe a boundary."@en ;
     rdfs:range ns1:DictionaryEntry .
 
-ns7:current a owl:ObjectProperty ;
+ns9:current a owl:ObjectProperty ;
     rdfs:comment "This is the individual, business, or organization who currently manages goods, services, or assets."@en ;
     rdfs:range ns1:Agent .
 
-ns7:currentState a owl:ObjectProperty ;
+ns9:currentState a owl:ObjectProperty ;
     rdfs:comment "This is the state of an affected Element."@en ;
-    rdfs:range ns7:State .
+    rdfs:range ns9:State .
 
-ns7:decisionProcess a owl:ObjectProperty ;
+ns9:decisionProcess a owl:ObjectProperty ;
     rdfs:comment "This is how the currentState of an affected Element is found."@en ;
-    rdfs:range ns7:DefinedStateProcess .
+    rdfs:range ns9:DefinedStateProcess .
 
-ns7:destructionPerformedBy a owl:ObjectProperty ;
+ns9:destructionPerformedBy a owl:ObjectProperty ;
     rdfs:comment "This is the agent that performed the act of destroying the item."@en ;
     rdfs:range ns1:Agent .
 
-ns7:dropoffLocation a owl:ObjectProperty ;
-    rdfs:comment "The location for dropping off or delivering a package or item."@en ;
+ns9:dropoffLocation a owl:ObjectProperty ;
+    rdfs:comment "A location where a package or an item is being dropped off or delivered."@en ;
     rdfs:range ns1:Location .
 
-ns7:forDropoffLocation a owl:ObjectProperty ;
-    rdfs:comment "The location that an item will be dropping off or delivered."@en ;
+ns9:forDropoffLocation a owl:ObjectProperty ;
+    rdfs:comment "A location where a package or an item will be dropped off or delivered."@en ;
     rdfs:range ns1:Location .
 
-ns7:forPickupLocation a owl:ObjectProperty ;
-    rdfs:comment "The location for picking up a package or item."@en ;
+ns9:forPickupLocation a owl:ObjectProperty ;
+    rdfs:comment "A location where a package or an item will be picked up."@en ;
     rdfs:range ns1:Location .
 
-ns7:pickupLocation a owl:ObjectProperty ;
-    rdfs:comment "The location for picking up a package or item."@en ;
+ns9:pickupLocation a owl:ObjectProperty ;
+    rdfs:comment "A location where a package or an item is being picked up."@en ;
     rdfs:range ns1:Location .
 
-ns7:plannedCurrent a owl:ObjectProperty ;
+ns9:plannedCurrent a owl:ObjectProperty ;
     rdfs:comment "This is the planned individual, business, or organization who currently manages goods, services, or assets."@en ;
     rdfs:range ns1:Agent .
 
-ns7:plannedInspectionLocation a owl:ObjectProperty ;
-    rdfs:comment "The planned location that a good, product or material is inspected."@en ;
+ns9:plannedInspectionLocation a owl:ObjectProperty ;
+    rdfs:comment "A planned location where a good, product, or material is inspected."@en ;
     rdfs:range ns1:Location .
 
-ns7:plannedPrevious a owl:ObjectProperty ;
+ns9:plannedPrevious a owl:ObjectProperty ;
     rdfs:comment "This is the planned individual, business, or organization who was previously managing goods, services, or assets."@en ;
     rdfs:range ns1:Agent .
 
-ns7:plannedProductOfResponsibilityChange a owl:ObjectProperty ;
+ns9:plannedProductOfResponsibilityChange a owl:ObjectProperty ;
     rdfs:comment "This is the planned product associated with the change of responsibility."@en ;
     rdfs:range ns1:Element .
 
-ns7:plannedStorageLocation a owl:ObjectProperty ;
-    rdfs:comment "The planned location that a good, product or material is stored."@en ;
+ns9:plannedStorageLocation a owl:ObjectProperty ;
+    rdfs:comment "A planned location where a good, product, or material is stored."@en ;
     rdfs:range ns1:Location .
 
-ns7:plannedTransportRoutes a owl:DatatypeProperty ;
-    rdfs:comment "A transport route refers to the planned path or network used to move people, goods, data, or resources from one location to another."@en ;
+ns9:plannedTransportRoute a owl:DatatypeProperty ;
+    rdfs:comment """A planned path used to move people, goods, data, or resources
+from one location to another."""@en ;
     rdfs:range xsd:string .
 
-ns7:previous a owl:ObjectProperty ;
+ns9:previous a owl:ObjectProperty ;
     rdfs:comment "This is the individual, business, or organization who was previously managing goods, services, or assets."@en ;
     rdfs:range ns1:Agent .
 
-ns7:responsibilityChangedOn a owl:ObjectProperty ;
-    rdfs:comment "The element that has it's responsibility changed."@en ;
+ns9:responsibilityChangedOn a owl:ObjectProperty ;
+    rdfs:comment "The element that has its responsibility changed."@en ;
     rdfs:range ns1:Element .
 
-ns7:transportRoute a owl:DatatypeProperty ;
+ns9:transportRoute a owl:DatatypeProperty ;
     rdfs:comment "A transport route refers to the specific path or network used to move people, goods, data, or resources from one location to another."@en ;
     rdfs:range xsd:string .
 
-ns7:validState a owl:ObjectProperty ;
+ns9:validState a owl:ObjectProperty ;
     rdfs:comment "The valid state for DefinedStateProcess."@en ;
-    rdfs:range ns7:State .
+    rdfs:range ns9:State .
 
 ns1:Bom a owl:Class ;
     rdfs:comment """A container for a grouping of SPDX 3 content characterizing details
@@ -3452,152 +3630,152 @@ ns1:Bom a owl:Class ;
     rdfs:subClassOf ns1:Bundle ;
     sh:nodeKind sh:IRI .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/adler32> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/adler32> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "adler32" ;
     rdfs:comment "Adler-32 checksum is part of the widely used zlib compression library as defined in [RFC 1950](https://datatracker.ietf.org/doc/rfc1950/) Section 2.3."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/blake2b256> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/blake2b256> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "blake2b256" ;
     rdfs:comment "BLAKE2b algorithm with a digest size of 256, as defined in [RFC 7693](https://datatracker.ietf.org/doc/rfc7693/) Section 4."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/blake2b384> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/blake2b384> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "blake2b384" ;
     rdfs:comment "BLAKE2b algorithm with a digest size of 384, as defined in [RFC 7693](https://datatracker.ietf.org/doc/rfc7693/) Section 4."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/blake2b512> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/blake2b512> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "blake2b512" ;
     rdfs:comment "BLAKE2b algorithm with a digest size of 512, as defined in [RFC 7693](https://datatracker.ietf.org/doc/rfc7693/) Section 4."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/blake3> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/blake3> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "blake3" ;
     rdfs:comment "[BLAKE3](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf)"@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/crystalsDilithium> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/crystalsDilithium> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "crystalsDilithium" ;
     rdfs:comment "[Dilithium](https://pq-crystals.org/dilithium/)"@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/crystalsKyber> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/crystalsKyber> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "crystalsKyber" ;
     rdfs:comment "[Kyber](https://pq-crystals.org/kyber/)"@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/falcon> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/falcon> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "falcon" ;
     rdfs:comment "[FALCON](https://falcon-sign.info/falcon.pdf)"@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/md2> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/md2> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "md2" ;
     rdfs:comment "MD2 message-digest algorithm, as defined in [RFC 1319](https://datatracker.ietf.org/doc/rfc1319/)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/md4> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/md4> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "md4" ;
     rdfs:comment "MD4 message-digest algorithm, as defined in [RFC 1186](https://datatracker.ietf.org/doc/rfc1186/)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/md5> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/md5> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "md5" ;
     rdfs:comment "MD5 message-digest algorithm, as defined in [RFC 1321](https://datatracker.ietf.org/doc/rfc1321/)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/md6> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/md6> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "md6" ;
     rdfs:comment "[MD6 hash function](https://people.csail.mit.edu/rivest/pubs/RABCx08.pdf)"@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/other> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/other> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "other" ;
     rdfs:comment "any hashing algorithm that does not exist in this list of entries"@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha1> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha1> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "sha1" ;
     rdfs:comment "SHA-1, a secure hashing algorithm, as defined in [RFC 3174](https://datatracker.ietf.org/doc/rfc3174/)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha224> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha224> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "sha224" ;
     rdfs:comment "SHA-2 with a digest length of 224, as defined in [RFC 3874](https://datatracker.ietf.org/doc/rfc3874/)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha256> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha256> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "sha256" ;
     rdfs:comment "SHA-2 with a digest length of 256, as defined in [RFC 6234](https://datatracker.ietf.org/doc/rfc6234/)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha384> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha384> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "sha384" ;
     rdfs:comment "SHA-2 with a digest length of 384, as defined in [RFC 6234](https://datatracker.ietf.org/doc/rfc6234/)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha3_224> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha3_224> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "sha3_224" ;
     rdfs:comment "SHA-3 with a digest length of 224, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha3_256> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha3_256> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "sha3_256" ;
     rdfs:comment "SHA-3 with a digest length of 256, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha3_384> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha3_384> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "sha3_384" ;
     rdfs:comment "SHA-3 with a digest length of 384, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha3_512> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha3_512> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "sha3_512" ;
     rdfs:comment "SHA-3 with a digest length of 512, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha512> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha512> a owl:NamedIndividual,
         ns1:HashAlgorithm ;
     rdfs:label "sha512" ;
     rdfs:comment "SHA-2 with a digest length of 512, as defined in [RFC 6234](https://datatracker.ietf.org/doc/rfc6234/)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/build> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/build> a owl:NamedIndividual,
         ns1:LifecycleScopeType ;
     rdfs:label "build" ;
     rdfs:comment "A relationship has specific context implications during an element's build phase, during development."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/decommission> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/decommission> a owl:NamedIndividual,
         ns1:LifecycleScopeType ;
     rdfs:label "decommission" ;
     rdfs:comment "A relationship has specific context implications for a product's retirement and/or decommissioning."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/design> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/design> a owl:NamedIndividual,
         ns1:LifecycleScopeType ;
     rdfs:label "design" ;
     rdfs:comment "A relationship has specific context implications during an element's design."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/development> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/development> a owl:NamedIndividual,
         ns1:LifecycleScopeType ;
     rdfs:label "development" ;
     rdfs:comment "A relationship has specific context implications during development phase of an element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/other> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/other> a owl:NamedIndividual,
         ns1:LifecycleScopeType ;
     rdfs:label "other" ;
     rdfs:comment "A relationship has other specific context information necessary to capture that the above set of enumerations does not handle."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/runtime> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/runtime> a owl:NamedIndividual,
         ns1:LifecycleScopeType ;
     rdfs:label "runtime" ;
     rdfs:comment "A relationship has specific context implications during the execution phase of an element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/test> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/test> a owl:NamedIndividual,
         ns1:LifecycleScopeType ;
     rdfs:label "test" ;
     rdfs:comment "A relationship has specific context implications during an element's testing phase, during development."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/LifecycleScopeType/update> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/update> a owl:NamedIndividual,
         ns1:LifecycleScopeType ;
     rdfs:label "update" ;
     rdfs:comment "A relationship has specific context implications for a product update."@en .
@@ -3611,37 +3789,37 @@ ns1:Organization a owl:Class,
             sh:nodeKind sh:IRI ;
             sh:path ns1:headquartersLocation ] .
 
-<https://spdx.org/rdf/3.1/terms/Core/SupportType/deployed> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/SupportType/deployed> a owl:NamedIndividual,
         ns1:SupportType ;
     rdfs:label "deployed" ;
     rdfs:comment "In addition to being supported by the supplier, the software is known to have been deployed and is in use. For a software as a service provider, this implies the software is now available as a service."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/SupportType/development> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/SupportType/development> a owl:NamedIndividual,
         ns1:SupportType ;
     rdfs:label "development" ;
     rdfs:comment "The artifact is in active development and is not considered ready for formal support from the supplier."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/SupportType/endOfSupport> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/SupportType/endOfSupport> a owl:NamedIndividual,
         ns1:SupportType ;
     rdfs:label "endOfSupport" ;
     rdfs:comment "There is a defined end of support for the artifact from the supplier. This may also be referred to as end of life. There is a validUntilDate that can be used to signal when support ends for the artifact."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/SupportType/limitedSupport> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/SupportType/limitedSupport> a owl:NamedIndividual,
         ns1:SupportType ;
     rdfs:label "limitedSupport" ;
     rdfs:comment "The artifact has been released, and there is limited support available from the supplier. There is a validUntilDate that can provide additional information about the duration of support."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/SupportType/noAssertion> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/SupportType/noAssertion> a owl:NamedIndividual,
         ns1:SupportType ;
     rdfs:label "noAssertion" ;
     rdfs:comment "No assertion about the type of support is made. This is considered the default if no other support type is used."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/SupportType/noSupport> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/SupportType/noSupport> a owl:NamedIndividual,
         ns1:SupportType ;
     rdfs:label "noSupport" ;
     rdfs:comment "There is no support for the artifact from the supplier, consumer assumes any support obligations."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/SupportType/support> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/SupportType/support> a owl:NamedIndividual,
         ns1:SupportType ;
     rdfs:label "support" ;
     rdfs:comment "The artifact has been released, and is supported from the supplier. There is a validUntilDate that can provide additional information about the duration of support."@en .
@@ -3652,7 +3830,7 @@ ns1:algorithm a owl:ObjectProperty ;
 
 ns1:extension a owl:ObjectProperty ;
     rdfs:comment "Specifies an Extension characterization of some aspect of an Element."@en ;
-    rdfs:range <https://spdx.org/rdf/3.1/terms/Extension/Extension> .
+    rdfs:range <https://spdx.org/rdf/3/terms/Extension/Extension> .
 
 ns1:hashValue a owl:DatatypeProperty ;
     rdfs:comment "The result of applying a hash algorithm to an Element."@en ;
@@ -3676,260 +3854,260 @@ ns1:verifiedUsing a owl:ObjectProperty ;
 asserted."""@en ;
     rdfs:range ns1:IntegrityMethod .
 
-ns9:deprecatedVersion a owl:DatatypeProperty ;
+ns10:deprecatedVersion a owl:DatatypeProperty ;
     rdfs:comment """Specifies the SPDX License List version in which this license or exception
 identifier was deprecated."""@en ;
     rdfs:range xsd:string .
 
-ns9:licenseXml a owl:DatatypeProperty ;
+ns10:licenseXml a owl:DatatypeProperty ;
     rdfs:comment """Identifies all the text and metadata associated with a license in the license
 XML format."""@en ;
     rdfs:range xsd:string .
 
-ns9:listVersionAdded a owl:DatatypeProperty ;
+ns10:listVersionAdded a owl:DatatypeProperty ;
     rdfs:comment """Specifies the SPDX License List version in which this ListedLicense or
 ListedLicenseException identifier was first added."""@en ;
     rdfs:range xsd:string .
 
-ns9:member a owl:ObjectProperty ;
+ns10:member a owl:ObjectProperty ;
     rdfs:comment "A license expression participating in a license set."@en ;
-    rdfs:range <https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo> .
+    rdfs:range <https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo> .
 
-ns9:obsoletedBy a owl:DatatypeProperty ;
+ns10:obsoletedBy a owl:DatatypeProperty ;
     rdfs:comment """Specifies the licenseId that is preferred to be used in place of a deprecated
 License or LicenseAddition."""@en ;
     rdfs:range xsd:string .
 
-ns9:seeAlso a owl:DatatypeProperty ;
+ns10:seeAlso a owl:DatatypeProperty ;
     rdfs:comment "Contains a URL where the License or LicenseAddition can be found in use."@en ;
     rdfs:range xsd:anyURI .
 
-ns10:hazard a owl:ObjectProperty ;
+ns3:hazard a owl:ObjectProperty ;
     rdfs:comment "Hazards are potential sources of harm, danger, or adverse effects to people, property, the environment, or systems within or related to a specific piece of hardware."@en ;
     rdfs:range ns1:DefinedType .
 
-ns10:partNumber a owl:DatatypeProperty ;
+ns3:partNumber a owl:DatatypeProperty ;
     rdfs:comment "Product Part Number as defined by OEM."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/critical> a owl:NamedIndividual,
-        ns4:CvssSeverityType ;
+<https://spdx.org/rdf/3/terms/Security/CvssSeverityType/critical> a owl:NamedIndividual,
+        ns5:CvssSeverityType ;
     rdfs:label "critical" ;
     rdfs:comment "When a CVSS score is between 9.0 - 10.0."@en .
 
-<https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/high> a owl:NamedIndividual,
-        ns4:CvssSeverityType ;
+<https://spdx.org/rdf/3/terms/Security/CvssSeverityType/high> a owl:NamedIndividual,
+        ns5:CvssSeverityType ;
     rdfs:label "high" ;
     rdfs:comment "When a CVSS score is between 7.0 - 8.9."@en .
 
-<https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/low> a owl:NamedIndividual,
-        ns4:CvssSeverityType ;
+<https://spdx.org/rdf/3/terms/Security/CvssSeverityType/low> a owl:NamedIndividual,
+        ns5:CvssSeverityType ;
     rdfs:label "low" ;
     rdfs:comment "When a CVSS score is between 0.1 - 3.9."@en .
 
-<https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/medium> a owl:NamedIndividual,
-        ns4:CvssSeverityType ;
+<https://spdx.org/rdf/3/terms/Security/CvssSeverityType/medium> a owl:NamedIndividual,
+        ns5:CvssSeverityType ;
     rdfs:label "medium" ;
     rdfs:comment "When a CVSS score is between 4.0 - 6.9."@en .
 
-<https://spdx.org/rdf/3.1/terms/Security/CvssSeverityType/none> a owl:NamedIndividual,
-        ns4:CvssSeverityType ;
+<https://spdx.org/rdf/3/terms/Security/CvssSeverityType/none> a owl:NamedIndividual,
+        ns5:CvssSeverityType ;
     rdfs:label "none" ;
     rdfs:comment "When a CVSS score is 0.0."@en .
 
-ns4:modifiedTime a owl:DatatypeProperty ;
+ns5:modifiedTime a owl:DatatypeProperty ;
     rdfs:comment "Specifies a time when a vulnerability assessment was modified"@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns4:publishedTime a owl:DatatypeProperty ;
+ns5:publishedTime a owl:DatatypeProperty ;
     rdfs:comment "Specifies the time when a vulnerability was published."@en ;
     rdfs:range xsd:dateTimeStamp .
 
-ns4:severity a owl:ObjectProperty ;
+ns5:severity a owl:ObjectProperty ;
     rdfs:comment "Specifies the CVSS qualitative severity rating of a vulnerability in relation to a piece of software."@en ;
-    rdfs:range ns4:CvssSeverityType .
+    rdfs:range ns5:CvssSeverityType .
 
-ns4:withdrawnTime a owl:DatatypeProperty ;
+ns5:withdrawnTime a owl:DatatypeProperty ;
     rdfs:comment "Specified the time and date when a vulnerability was withdrawn."@en ;
     rdfs:range xsd:dateTimeStamp .
 
-<https://spdx.org/rdf/3.1/terms/SimpleLicensing/licenseText> a owl:DatatypeProperty ;
+<https://spdx.org/rdf/3/terms/SimpleLicensing/licenseText> a owl:DatatypeProperty ;
     rdfs:comment "Identifies the full text of a License or Addition."@en ;
     rdfs:range xsd:string .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/application> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/application> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "application" ;
     rdfs:comment "The Element is a software application."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/archive> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/archive> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "archive" ;
     rdfs:comment "The Element is an archived collection of one or more files (.tar, .zip, etc.)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/bom> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/bom> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "bom" ;
     rdfs:comment "The Element is a bill of materials."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/configuration> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/configuration> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "configuration" ;
     rdfs:comment "The Element is configuration data."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/container> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/container> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "container" ;
     rdfs:comment "The Element is a container image which can be used by a container runtime application."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/data> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/data> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "data" ;
     rdfs:comment "The Element is data."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/device> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/device> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "device" ;
     rdfs:comment "The Element refers to a chipset, processor, or electronic board."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/deviceDriver> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/deviceDriver> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "deviceDriver" ;
     rdfs:comment "The Element represents software that controls hardware devices."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/diskImage> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/diskImage> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "diskImage" ;
     rdfs:comment "The Element refers to a disk image that can be written to a disk, booted in a VM, etc. A disk image typically contains most or all of the components necessary to boot, such as bootloaders, kernels, firmware, userspace, etc."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/documentation> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/documentation> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "documentation" ;
     rdfs:comment "The Element is documentation."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/evidence> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/evidence> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "evidence" ;
     rdfs:comment "The Element is the evidence that a specification or requirement has been fulfilled."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/executable> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/executable> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "executable" ;
     rdfs:comment "The Element is an Artifact that can be run on a computer."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/file> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/file> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "file" ;
     rdfs:comment "The Element is a single file which can be independently distributed (configuration file, statically linked binary, Kubernetes deployment, etc.)."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/filesystemImage> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/filesystemImage> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "filesystemImage" ;
     rdfs:comment "The Element is a file system image that can be written to a disk (or virtual) partition."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/firmware> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/firmware> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "firmware" ;
     rdfs:comment "The Element provides low level control over a device's hardware."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/framework> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/framework> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "framework" ;
     rdfs:comment "The Element is a software framework."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/install> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/install> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "install" ;
     rdfs:comment "The Element is used to install software on disk."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/library> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/library> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "library" ;
     rdfs:comment "The Element is a software library."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/manifest> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/manifest> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "manifest" ;
     rdfs:comment "The Element is a software manifest."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/model> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/model> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "model" ;
     rdfs:comment "The Element is a machine learning or artificial intelligence model."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/module> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/module> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "module" ;
     rdfs:comment "The Element is a module of a piece of software."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/operatingSystem> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/operatingSystem> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "operatingSystem" ;
     rdfs:comment "The Element is an operating system."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/other> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/other> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "other" ;
     rdfs:comment "The Element doesn't fit into any of the other categories."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/patch> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/patch> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "patch" ;
     rdfs:comment "The Element contains a set of changes to update, fix, or improve another Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/platform> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/platform> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "platform" ;
     rdfs:comment "The Element represents a runtime environment."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/requirement> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/requirement> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "requirement" ;
     rdfs:comment "The Element provides a requirement needed as input for another Element."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/source> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/source> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "source" ;
     rdfs:comment "The Element is a single or a collection of source files."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/specification> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/specification> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "specification" ;
     rdfs:comment "The Element is a plan, guideline or strategy how to create, perform or analyze an application."@en .
 
-<https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/test> a owl:NamedIndividual,
-        ns6:SoftwarePurpose ;
+<https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/test> a owl:NamedIndividual,
+        ns4:SoftwarePurpose ;
     rdfs:label "test" ;
     rdfs:comment "The Element is a test used to verify functionality on a software element."@en .
 
-<https://spdx.org/rdf/3.1/terms/SupplyChain/ResponsibilityType/custody> a owl:NamedIndividual,
-        ns7:ResponsibilityType ;
+<https://spdx.org/rdf/3/terms/SupplyChain/ResponsibilityType/custody> a owl:NamedIndividual,
+        ns9:ResponsibilityType ;
     rdfs:label "custody" ;
     rdfs:comment "Custody refers to the responsibility, control, and safekeeping of an asset, person, or legal entity. It involves both physical possession and legal authority over something or someone."@en .
 
-<https://spdx.org/rdf/3.1/terms/SupplyChain/ResponsibilityType/ownership> a owl:NamedIndividual,
-        ns7:ResponsibilityType ;
+<https://spdx.org/rdf/3/terms/SupplyChain/ResponsibilityType/ownership> a owl:NamedIndividual,
+        ns9:ResponsibilityType ;
     rdfs:label "ownership" ;
     rdfs:comment "Ownership refers to the legal right to control, manage, and benefit from an asset, resource, or responsibility. It establishes authority, accountability, and entitlements over something, whether it's property, a business, intellectual property, or responsibilities."@en .
 
-ns7:responsibilityCategory a owl:ObjectProperty ;
-    rdfs:comment "Requirements can be categorized into various types based on their focus, purpose, and scope."@en ;
-    rdfs:range ns7:ResponsibilityType .
+ns9:responsibilityCategory a owl:ObjectProperty ;
+    rdfs:comment "responsibilityCategory classifies the nature or domain of a responsibility transfer."@en ;
+    rdfs:range ns9:ResponsibilityType .
 
-ns5:EnergyConsumption a owl:Class,
+ns7:EnergyConsumption a owl:Class,
         sh:NodeShape ;
     rdfs:comment """A class for describing the energy consumption incurred by an AI model in
 different stages of its lifecycle."""@en ;
     sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:class ns5:EnergyConsumptionDescription ;
+    sh:property [ sh:class ns7:EnergyConsumptionDescription ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns5:finetuningEnergyConsumption ],
-        [ sh:class ns5:EnergyConsumptionDescription ;
+            sh:path ns7:trainingEnergyConsumption ],
+        [ sh:class ns7:EnergyConsumptionDescription ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns5:trainingEnergyConsumption ],
-        [ sh:class ns5:EnergyConsumptionDescription ;
+            sh:path ns7:inferenceEnergyConsumption ],
+        [ sh:class ns7:EnergyConsumptionDescription ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns5:inferenceEnergyConsumption ] .
+            sh:path ns7:finetuningEnergyConsumption ] .
 
 ns1:Bundle a owl:Class,
         sh:NodeShape ;
@@ -3946,34 +4124,34 @@ ns1:ElementCollection a owl:Class,
     rdfs:comment "A collection of Elements, not necessarily with unifying context."@en ;
     rdfs:subClassOf ns1:Element ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:Element ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:rootElement ],
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/Core/ElementCollection is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns1:ElementCollection ] ;
+            sh:path rdf:type ],
         [ sh:class ns1:Element ;
             sh:nodeKind sh:IRI ;
             sh:path ns1:element ],
-        [ sh:message "https://spdx.org/rdf/3.1/terms/Core/ElementCollection is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns1:ElementCollection ] ;
-            sh:path rdf:type ],
         [ sh:class ns1:ProfileIdentifierType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/core> <https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/software> <https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/simpleLicensing> <https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/expandedLicensing> <https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/security> <https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/build> <https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/ai> <https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/dataset> <https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/extension> <https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/lite> <https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/hardware> <https://spdx.org/rdf/3.1/terms/Core/ProfileIdentifierType/supplyChain> ) ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/core> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/software> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/simpleLicensing> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/expandedLicensing> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/security> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/build> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/ai> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/dataset> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/extension> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/lite> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/hardware> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/supplyChain> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/operations> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/functionalSafety> <https://spdx.org/rdf/3/terms/Core/ProfileIdentifierType/service> ) ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:profileConformance ] .
+            sh:path ns1:profileConformance ],
+        [ sh:class ns1:Element ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:rootElement ] .
 
 ns1:ElementMap a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A key with an Element."@en ;
     sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:class ns1:Element ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:elementValue ],
-        [ sh:datatype xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:key ] .
+            sh:path ns1:key ],
+        [ sh:class ns1:Element ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:elementValue ] .
 
 ns1:ExternalMap a owl:Class,
         sh:NodeShape ;
@@ -3982,16 +4160,16 @@ external to that SpdxDocument."""@en ;
     sh:nodeKind sh:BlankNodeOrIRI ;
     sh:property [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
-            sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:externalSpdxId ],
+            sh:path ns1:locationHint ],
         [ sh:class ns1:IntegrityMethod ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:path ns1:verifiedUsing ],
         [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
+            sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:locationHint ],
+            sh:path ns1:externalSpdxId ],
         [ sh:class ns1:Artifact ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
@@ -4001,7 +4179,15 @@ ns1:ExternalRef a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A reference to a resource outside the scope of SPDX 3 content related to an Element."@en ;
     sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:datatype xsd:string ;
+    sh:property [ sh:class ns1:ExternalRefType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/ExternalRefType/altDownloadLocation> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/altWebPage> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/binaryArtifact> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/bom> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/bower> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/buildMeta> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/buildSystem> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/chat> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/certificationReport> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/componentAnalysisReport> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/cwe> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/documentation> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/dynamicAnalysisReport> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/eolNotice> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/exportControlAssessment> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/funding> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/issueTracker> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/mailingList> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/mavenCentral> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/metrics> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/npm> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/nuget> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/license> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/other> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/privacyAssessment> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/productMetadata> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/purchaseOrder> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/qualityAssessmentReport> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/releaseNotes> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/releaseHistory> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/riskAssessment> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/runtimeAnalysisReport> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/secureSoftwareAttestation> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityAdvisory> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityAdversaryModel> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityFix> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityOther> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityPenTestReport> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityPolicy> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/securityThreatModel> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/socialMedia> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/sourceArtifact> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/staticAnalysisReport> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/support> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/vcs> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/vulnerabilityDisclosureReport> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/vulnerabilityExploitabilityAssessment> <https://spdx.org/rdf/3/terms/Core/ExternalRefType/x509Cert> ) ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:externalRefType ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:locator ],
+        [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path ns1:comment ],
@@ -4009,32 +4195,24 @@ ns1:ExternalRef a owl:Class,
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path ns1:contentType ;
-            sh:pattern "^[^\\/]+\\/[^\\/]+$" ],
-        [ sh:class ns1:ExternalRefType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/altDownloadLocation> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/altWebPage> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/binaryArtifact> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/bower> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/buildMeta> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/buildSystem> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/chat> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/certificationReport> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/componentAnalysisReport> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/cwe> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/documentation> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/dynamicAnalysisReport> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/eolNotice> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/exportControlAssessment> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/funding> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/issueTracker> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/mailingList> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/mavenCentral> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/metrics> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/npm> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/nuget> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/license> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/other> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/privacyAssessment> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/productMetadata> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/purchaseOrder> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/qualityAssessmentReport> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/releaseNotes> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/releaseHistory> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/riskAssessment> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/runtimeAnalysisReport> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/secureSoftwareAttestation> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityAdvisory> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityAdversaryModel> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityFix> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityOther> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityPenTestReport> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityPolicy> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/securityThreatModel> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/socialMedia> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/sourceArtifact> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/staticAnalysisReport> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/support> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/vcs> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/vulnerabilityDisclosureReport> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/vulnerabilityExploitabilityAssessment> <https://spdx.org/rdf/3.1/terms/Core/ExternalRefType/x509Cert> ) ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:externalRefType ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:locator ] .
+            sh:pattern "^[^\\/]+\\/[^\\/]+$" ] .
 
 ns1:Hash a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A mathematically calculated representation of a grouping of data."@en ;
     rdfs:subClassOf ns1:IntegrityMethod ;
     sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:class ns1:HashAlgorithm ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/adler32> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/blake2b256> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/blake2b384> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/blake2b512> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/blake3> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/crystalsDilithium> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/crystalsKyber> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/falcon> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/md2> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/md4> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/md5> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/md6> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/other> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha1> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha224> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha256> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha384> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha512> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha3_224> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha3_256> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha3_384> <https://spdx.org/rdf/3.1/terms/Core/HashAlgorithm/sha3_512> ) ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:algorithm ],
-        [ sh:datatype xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:hashValue ] .
+            sh:path ns1:hashValue ],
+        [ sh:class ns1:HashAlgorithm ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/adler32> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/blake2b256> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/blake2b384> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/blake2b512> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/blake3> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/crystalsDilithium> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/crystalsKyber> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/falcon> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/md2> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/md4> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/md5> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/md6> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/other> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha1> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha224> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha256> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha384> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha512> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha3_224> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha3_256> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha3_384> <https://spdx.org/rdf/3/terms/Core/HashAlgorithm/sha3_512> ) ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:algorithm ] .
 
 ns1:IndividualElement a owl:Class ;
     rdfs:comment """A concrete subclass of Element used by Individuals in the
@@ -4051,66 +4229,90 @@ ns1:NamespaceMap a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A mapping between prefixes and namespace partial URIs."@en ;
     sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:datatype xsd:string ;
+    sh:property [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:prefix ],
-        [ sh:datatype xsd:anyURI ;
+            sh:path ns1:namespace ],
+        [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:namespace ] .
+            sh:path ns1:prefix ] .
 
-<https://spdx.org/rdf/3.1/terms/Core/PresenceType/no> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/PresenceType/no> a owl:NamedIndividual,
         ns1:PresenceType ;
     rdfs:label "no" ;
     rdfs:comment "Indicates absence of the field."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/PresenceType/noAssertion> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/PresenceType/noAssertion> a owl:NamedIndividual,
         ns1:PresenceType ;
     rdfs:label "noAssertion" ;
     rdfs:comment "Makes no assertion about the field."@en .
 
-<https://spdx.org/rdf/3.1/terms/Core/PresenceType/yes> a owl:NamedIndividual,
+<https://spdx.org/rdf/3/terms/Core/PresenceType/yes> a owl:NamedIndividual,
         ns1:PresenceType ;
     rdfs:label "yes" ;
     rdfs:comment "Indicates presence of the field."@en .
 
-ns1:Tool a owl:Class ;
+ns1:Role a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "A Role defines a specific position, function, or capacity that an entity may assume within any relevant context."@en ;
+    rdfs:subClassOf ns1:Element ;
+    sh:nodeKind sh:IRI ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:authorization ],
+        [ sh:class ns1:Requirement ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:responsibility ],
+        [ sh:class ns1:DefinedType ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns1:referenceSpecification ],
+        [ sh:class ns1:Requirement ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:roleQualification ] .
+
+ns1:Tool a owl:Class,
+        sh:NodeShape ;
     rdfs:comment "An element of hardware and/or software utilized to carry out a particular function."@en ;
     rdfs:subClassOf ns1:Element ;
-    sh:nodeKind sh:IRI .
+    sh:nodeKind sh:IRI ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:version ] .
 
 ns1:contentType a owl:DatatypeProperty ;
     rdfs:comment "Provides information about the content type of an Element or a property."@en ;
     rdfs:range xsd:string .
 
-ns9:IndividualLicensingInfo a owl:Class ;
+ns10:IndividualLicensingInfo a owl:Class ;
     rdfs:comment """A concrete subclass of AnyLicenseInfo used by Individuals in the
 ExpandedLicensing profile."""@en ;
-    rdfs:subClassOf <https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo> ;
+    rdfs:subClassOf <https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo> ;
     sh:nodeKind sh:IRI .
 
-<https://spdx.org/rdf/3.1/terms/Extension/CdxPropertyEntry> a owl:Class,
+<https://spdx.org/rdf/3/terms/Extension/CdxPropertyEntry> a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A property name with an associated value."@en ;
     sh:nodeKind sh:BlankNodeOrIRI ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
-            sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Extension/cdxPropName> ],
+            sh:path <https://spdx.org/rdf/3/terms/Extension/cdxPropValue> ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
+            sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Extension/cdxPropValue> ] .
+            sh:path <https://spdx.org/rdf/3/terms/Extension/cdxPropName> ] .
 
-<https://spdx.org/rdf/3.1/terms/Extension/Extension> a owl:Class ;
+<https://spdx.org/rdf/3/terms/Extension/Extension> a owl:Class ;
     rdfs:comment "A characterization of some aspect of an Element that is associated with the Element in a generalized fashion."@en ;
     sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:message "https://spdx.org/rdf/3.1/terms/Extension/Extension is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue <https://spdx.org/rdf/3.1/terms/Extension/Extension> ] ;
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/Extension/Extension is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue <https://spdx.org/rdf/3/terms/Extension/Extension> ] ;
             sh:path rdf:type ] .
 
 ns2:RequirementVerification a owl:Class,
@@ -4118,244 +4320,287 @@ ns2:RequirementVerification a owl:Class,
     rdfs:comment "RequirementVerification class defines the base properties of a verification."@en ;
     rdfs:subClassOf ns1:Element ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns2:verificationRationale ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns2:verificationPrecondition ],
-        [ sh:class ns1:ExternalIdentifier ;
+    sh:property [ sh:class ns1:ExternalIdentifier ;
             sh:maxCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns2:verificationUUID ],
+            sh:path ns2:verificationUID ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:verificationPostcondition ],
         [ sh:class ns2:VerificationType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/analysis> <https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/assessment> <https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/audit> <https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/demonstration> <https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/inspection> <https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/other> <https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/review> <https://spdx.org/rdf/3.1/terms/FunctionalSafety/VerificationType/test> ) ;
+            sh:in ( <https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/analysis> <https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/assessment> <https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/audit> <https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/demonstration> <https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/inspection> <https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/other> <https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/review> <https://spdx.org/rdf/3/terms/FunctionalSafety/VerificationType/test> ) ;
             sh:nodeKind sh:IRI ;
             sh:path ns2:verificationMethod ],
         [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns2:verificationPostcondition ] .
+            sh:path ns1:rationale ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns2:verificationPrecondition ] .
 
-<https://spdx.org/rdf/3.1/terms/Operations/Project> a owl:Class,
+<https://spdx.org/rdf/3/terms/Operations/Project> a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Temporary endeavor with a beginning and an end and that must be used to create a unique product, service or result."@en ;
     rdfs:subClassOf ns1:Bundle ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:dateTimeStamp ;
+    sh:property [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/projectStartTime> ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/projectEndTime> ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+            sh:path <https://spdx.org/rdf/3/terms/Operations/projectContract> ],
         [ sh:class ns1:Agent ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/projectOwner> ],
+            sh:path <https://spdx.org/rdf/3/terms/Operations/projectOwner> ],
         [ sh:class ns1:Agent ;
             sh:nodeKind sh:IRI ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/projectSponsor> ],
-        [ sh:datatype xsd:anyURI ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/projectContract> ],
+            sh:path <https://spdx.org/rdf/3/terms/Operations/projectSponsor> ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/projectTitle> ] .
+            sh:path <https://spdx.org/rdf/3/terms/Operations/projectTitle> ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:endTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:startTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ] .
 
-ns4:score a owl:DatatypeProperty ;
+ns5:score a owl:DatatypeProperty ;
     rdfs:comment "Provides a numerical (0-10) representation of the severity of a vulnerability."@en ;
     rdfs:range xsd:decimal .
 
-ns4:vectorString a owl:DatatypeProperty ;
+ns5:vectorString a owl:DatatypeProperty ;
     rdfs:comment "Specifies the CVSS vector string for a vulnerability."@en ;
     rdfs:range xsd:string .
 
-ns6:ContentIdentifier a owl:Class,
+ns4:ContentIdentifier a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A canonical, unique, immutable identifier."@en ;
     rdfs:subClassOf ns1:IntegrityMethod ;
     sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:class ns6:ContentIdentifierType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Software/ContentIdentifierType/gitoid> <https://spdx.org/rdf/3.1/terms/Software/ContentIdentifierType/swhid> ) ;
+    sh:property [ sh:class ns4:ContentIdentifierType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Software/ContentIdentifierType/gitoid> <https://spdx.org/rdf/3/terms/Software/ContentIdentifierType/swhid> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns6:contentIdentifierType ],
+            sh:path ns4:contentIdentifierType ],
         [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns6:contentIdentifierValue ] .
+            sh:path ns4:contentIdentifierValue ] .
 
-ns6:File a owl:Class,
+ns4:File a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Refers to any object that stores content on a computer."@en ;
-    rdfs:subClassOf ns6:SoftwareArtifact ;
+    rdfs:subClassOf ns4:SoftwareArtifact ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns6:FileKindType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Software/FileKindType/file> <https://spdx.org/rdf/3.1/terms/Software/FileKindType/directory> ) ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns6:fileKind ],
-        [ sh:datatype xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path ns1:contentType ;
-            sh:pattern "^[^\\/]+\\/[^\\/]+$" ] .
+            sh:pattern "^[^\\/]+\\/[^\\/]+$" ],
+        [ sh:class ns4:FileKindType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Software/FileKindType/file> <https://spdx.org/rdf/3/terms/Software/FileKindType/directory> <https://spdx.org/rdf/3/terms/Software/FileKindType/symlink> ) ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns4:fileKind ] .
 
-ns6:Package a owl:Class,
+ns4:Package a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Refers to any unit of content that can be associated with a distribution of
 software."""@en ;
-    rdfs:subClassOf ns6:SoftwareArtifact ;
+    rdfs:subClassOf ns4:SoftwareArtifact ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns6:packageUrl ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns6:sourceInfo ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns6:packageVersion ],
+            sh:path ns4:downloadLocation ],
         [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns6:homePage ],
+            sh:path ns4:packageUrl ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns4:sourceInfo ],
         [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns6:downloadLocation ] .
+            sh:path ns4:homePage ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns4:packageVersion ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:version ] .
 
-ns7:DefinedStateProcess a owl:Class,
+ns9:DefinedStateProcess a owl:Class,
         sh:NodeShape ;
     rdfs:comment "This process is used to determine the state of an affected Element."@en ;
-    rdfs:subClassOf ns7:UseProcess ;
+    rdfs:subClassOf ns9:UseProcess ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns7:State ;
+    sh:property [ sh:class ns9:State ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns7:validState ] .
+            sh:path ns9:validState ] .
 
 ns1:AnnotationType a owl:Class ;
     rdfs:comment "Specifies the type of an annotation."@en .
 
-ns10:Hardware a owl:Class,
+ns1:endTime a owl:DatatypeProperty ;
+    rdfs:comment """The point in time when an element or an action ends,
+becomes no longer applicable, or becomes no longer valid."""@en ;
+    rdfs:range xsd:dateTimeStamp .
+
+ns1:startTime a owl:DatatypeProperty ;
+    rdfs:comment """The point in time when an element or an action starts,
+becomes applicable, or becomes valid."""@en ;
+    rdfs:range xsd:dateTimeStamp .
+
+ns3:Hardware a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Class that describes an instance of Hardware."@en ;
     rdfs:subClassOf ns1:Artifact ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:message "https://spdx.org/rdf/3.1/terms/Hardware/Hardware is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns10:Hardware ] ;
-            sh:path rdf:type ],
-        [ sh:class ns1:DefinedType ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns10:hazard ],
-        [ sh:class ns1:DictionaryEntry ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns10:additionalInformation ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns10:serialNumber ],
+    sh:property [ sh:class ns1:Specification ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns3:additionalInformationSpecification ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns10:partNumber ],
+            sh:path ns3:partNumber ],
         [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns10:releaseDate ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+            sh:path ns3:releaseDate ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:class ns1:DictionaryEntry ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns3:additionalInformation ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:version ],
+        [ sh:class ns1:DefinedType ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns3:hazard ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns3:serialNumber ],
+        [ sh:class ns1:DefinedType ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns3:category ],
+        [ sh:message "https://spdx.org/rdf/3/terms/Hardware/Hardware is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns3:Hardware ] ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns3:batchNumber ],
         [ sh:class ns1:Agent ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns10:productAgent ],
-        [ sh:class ns1:DefinedType ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns10:category ],
-        [ sh:class ns1:Specification ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns10:additionalInformationSpecification ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns10:hardwareVersion ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns10:batchNumber ] .
+            sh:path ns3:productAgent ] .
 
-<https://spdx.org/rdf/3.1/terms/Operations/ExportControlClassification> a owl:Class,
+<https://spdx.org/rdf/3/terms/Operations/ExportControlClassification> a owl:Class,
         sh:NodeShape ;
-    rdfs:comment "Assement of an Element for export control classification."@en ;
+    rdfs:comment "Assessment of an Element for export control classification."@en ;
     sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:class ns1:Specification ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path <https://spdx.org/rdf/3/terms/Operations/exportingCountry> ;
+            sh:pattern "^[A-Z]{3}$" ],
+        [ sh:class ns1:Specification ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/exportControlSpecification> ],
+            sh:path <https://spdx.org/rdf/3/terms/Operations/exportControlSpecification> ],
         [ sh:datatype xsd:positiveInteger ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/weight> ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:comment ],
+            sh:path <https://spdx.org/rdf/3/terms/Operations/weight> ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/exportClassification> ],
+            sh:path <https://spdx.org/rdf/3/terms/Operations/exportClassification> ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
-            sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/Operations/exportingCountry> ;
-            sh:pattern "^[A-Z]{3}$" ] .
+            sh:path ns1:comment ] .
 
-ns4:ExploitCatalogType a owl:Class ;
+ns5:ExploitCatalogType a owl:Class ;
     rdfs:comment "Specifies the exploit catalog type."@en .
 
-ns6:ContentIdentifierType a owl:Class ;
+ns4:ContentIdentifierType a owl:Class ;
     rdfs:comment "Specifies the type of a content identifier."@en .
 
-ns6:FileKindType a owl:Class ;
-    rdfs:comment "Enumeration of the different kinds of SPDX file."@en .
+ns4:SoftwareArtifact a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "A distinct article or unit related to Software."@en ;
+    rdfs:subClassOf ns1:Artifact ;
+    sh:nodeKind sh:IRI ;
+    sh:property [ sh:class ns4:ContentIdentifier ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns4:contentIdentifier ],
+        [ sh:message "https://spdx.org/rdf/3/terms/Software/SoftwareArtifact is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns4:SoftwareArtifact ] ;
+            sh:path rdf:type ],
+        [ sh:class ns4:SoftwarePurpose ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/application> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/archive> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/bom> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/configuration> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/container> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/data> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/device> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/diskImage> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/deviceDriver> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/documentation> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/evidence> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/executable> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/file> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/filesystemImage> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/firmware> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/framework> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/install> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/library> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/manifest> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/model> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/module> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/operatingSystem> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/other> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/patch> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/platform> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/requirement> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/source> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/specification> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/test> ) ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns4:additionalPurpose ],
+        [ sh:datatype xsd:nonNegativeInteger ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns4:artifactSize ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns4:attributionText ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns4:copyrightText ],
+        [ sh:class ns4:SoftwarePurpose ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/application> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/archive> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/bom> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/configuration> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/container> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/data> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/device> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/diskImage> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/deviceDriver> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/documentation> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/evidence> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/executable> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/file> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/filesystemImage> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/firmware> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/framework> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/install> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/library> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/manifest> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/model> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/module> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/operatingSystem> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/other> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/patch> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/platform> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/requirement> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/source> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/specification> <https://spdx.org/rdf/3/terms/Software/SoftwarePurpose/test> ) ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns4:primaryPurpose ] .
 
-ns7:ModifyAction a owl:Class ;
+ns9:ModifyAction a owl:Class ;
     rdfs:comment "An actual alteration of a product."@en ;
     rdfs:subClassOf ns1:Action ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:message "https://spdx.org/rdf/3.1/terms/SupplyChain/ModifyAction is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns7:ModifyAction ] ;
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/SupplyChain/ModifyAction is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns9:ModifyAction ] ;
             sh:path rdf:type ] .
 
-ns7:ModifyProcess a owl:Class ;
+ns9:ModifyProcess a owl:Class ;
     rdfs:comment "A prescribed alteration of a product."@en ;
     rdfs:subClassOf ns1:DefinedProcess ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:message "https://spdx.org/rdf/3.1/terms/SupplyChain/ModifyProcess is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns7:ModifyProcess ] ;
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/SupplyChain/ModifyProcess is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns9:ModifyProcess ] ;
             sh:path rdf:type ] .
 
-ns5:EnergyUnitType a owl:Class ;
+ns7:EnergyUnitType a owl:Class ;
     rdfs:comment "Unit of energy consumption."@en .
 
 ns1:PositiveIntegerRange a owl:Class,
@@ -4366,15 +4611,42 @@ ns1:PositiveIntegerRange a owl:Class,
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:endIntegerRange ],
+            sh:path ns1:beginIntegerRange ],
         [ sh:datatype xsd:positiveInteger ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:beginIntegerRange ] .
+            sh:path ns1:endIntegerRange ] .
 
 ns1:RelationshipCompleteness a owl:Class ;
     rdfs:comment "Indicates whether a relationship is known to be complete, incomplete, or if no assertion is made with respect to relationship completeness."@en .
+
+ns1:Requirement a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "A distinct unit representing a requirement, as used in systems, software, and hardware engineering."@en ;
+    rdfs:subClassOf ns1:Element ;
+    sh:nodeKind sh:IRI ;
+    sh:property [ sh:class ns1:RequirementStatusType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/RequirementStatusType/draft> <https://spdx.org/rdf/3/terms/Core/RequirementStatusType/reviewable> <https://spdx.org/rdf/3/terms/Core/RequirementStatusType/active> <https://spdx.org/rdf/3/terms/Core/RequirementStatusType/retired> <https://spdx.org/rdf/3/terms/Core/RequirementStatusType/backlog> ) ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:requirementStatus ],
+        [ sh:class ns1:LifecycleScopeType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/design> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/development> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/build> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/test> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/runtime> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/decommission> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/update> <https://spdx.org/rdf/3/terms/Core/LifecycleScopeType/other> ) ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:devLifecycleStage ],
+        [ sh:datatype xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:rationale ],
+        [ sh:class ns1:ExternalIdentifier ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns1:requirementUID ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:requirementStatement ] .
 
 ns1:SpdxOrganization a owl:NamedIndividual,
         ns1:Organization ;
@@ -4384,73 +4656,83 @@ ns1:SpdxOrganization a owl:NamedIndividual,
 
 ns1:UnitOfMeasure a owl:Class,
         sh:NodeShape ;
-    rdfs:comment "UnitofMeasure specify information structures through industry standards for Units of Measure, Quantity Kinds, Dimensions and Data Types."@en ;
+    rdfs:comment """UnitOfMeasure specify information structures through industry standards for
+Units of Measure, Quantity Kinds, Dimensions and Data Types."""@en ;
     sh:nodeKind sh:BlankNodeOrIRI ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:quantity ],
+            sh:path ns1:unitQUDT ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:unitQUDT ] .
+            sh:path ns1:quantity ] .
 
-ns9:ExtendableLicense a owl:Class ;
+ns1:rationale a owl:DatatypeProperty ;
+    rdfs:comment """A rationale is supporting information that provides the underlying
+justification or reasoning for an associated element, decision, or process."""@en ;
+    rdfs:range xsd:string .
+
+ns1:version a owl:DatatypeProperty ;
+    rdfs:comment "Version string for an Element."@en ;
+    rdfs:range xsd:string .
+
+ns10:ExtendableLicense a owl:Class ;
     rdfs:comment "Abstract class representing a License or an OrLaterOperator."@en ;
-    rdfs:subClassOf <https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo> ;
+    rdfs:subClassOf <https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo> ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:message "https://spdx.org/rdf/3.1/terms/ExpandedLicensing/ExtendableLicense is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns9:ExtendableLicense ] ;
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/ExpandedLicensing/ExtendableLicense is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns10:ExtendableLicense ] ;
             sh:path rdf:type ] .
 
-ns9:License a owl:Class,
+ns10:License a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Abstract class for the portion of an AnyLicenseInfo representing a license."@en ;
-    rdfs:subClassOf ns9:ExtendableLicense ;
+    rdfs:subClassOf ns10:ExtendableLicense ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:string ;
+    sh:property [ sh:datatype xsd:boolean ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns10:isDeprecatedLicenseId ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns10:standardLicenseTemplate ],
+        [ sh:datatype xsd:boolean ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns10:isFsfLibre ],
+        [ sh:datatype xsd:anyURI ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns10:seeAlso ],
+        [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/SimpleLicensing/licenseText> ],
+            sh:path <https://spdx.org/rdf/3/terms/SimpleLicensing/licenseText> ],
         [ sh:datatype xsd:boolean ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns9:isOsiApproved ],
+            sh:path ns10:isOsiApproved ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns9:obsoletedBy ],
+            sh:path ns10:obsoletedBy ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns9:licenseXml ],
-        [ sh:message "https://spdx.org/rdf/3.1/terms/ExpandedLicensing/License is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns9:License ] ;
-            sh:path rdf:type ],
-        [ sh:datatype xsd:boolean ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns9:isDeprecatedLicenseId ],
-        [ sh:datatype xsd:anyURI ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns9:seeAlso ],
-        [ sh:datatype xsd:boolean ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns9:isFsfLibre ],
+            sh:path ns10:standardLicenseHeader ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns9:standardLicenseTemplate ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns9:standardLicenseHeader ] .
+            sh:path ns10:licenseXml ],
+        [ sh:message "https://spdx.org/rdf/3/terms/ExpandedLicensing/License is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns10:License ] ;
+            sh:path rdf:type ] .
 
-ns9:LicenseAddition a owl:Class,
+ns10:LicenseAddition a owl:Class,
         sh:NodeShape ;
     rdfs:comment """Abstract class for additional text intended to be added to a License, but
 which is not itself a standalone License."""@en ;
@@ -4459,35 +4741,35 @@ which is not itself a standalone License."""@en ;
     sh:property [ sh:datatype xsd:boolean ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns9:isDeprecatedAdditionId ],
+            sh:path ns10:isDeprecatedAdditionId ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns9:licenseXml ],
+            sh:path ns10:obsoletedBy ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns10:standardAdditionTemplate ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns10:licenseXml ],
+        [ sh:message "https://spdx.org/rdf/3/terms/ExpandedLicensing/LicenseAddition is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns10:LicenseAddition ] ;
+            sh:path rdf:type ],
         [ sh:datatype xsd:anyURI ;
             sh:nodeKind sh:Literal ;
-            sh:path ns9:seeAlso ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns9:standardAdditionTemplate ],
-        [ sh:message "https://spdx.org/rdf/3.1/terms/ExpandedLicensing/LicenseAddition is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns9:LicenseAddition ] ;
-            sh:path rdf:type ],
+            sh:path ns10:seeAlso ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns9:additionText ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns9:obsoletedBy ] .
+            sh:path ns10:additionText ] .
 
 ns2:EvaluationResultType a owl:Class ;
-    rdfs:comment "EvaluationResultType describes the outcome of an evaluation or verification process with."@en .
+    rdfs:comment "Specifies the outcome of an evaluation or verification process."@en .
 
-ns10:Dimensions a owl:Class,
+ns3:Dimensions a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Dimensions generally refer to measurable extents or attributes that define the size, shape, or scale of an object, system, or concept."@en ;
     sh:nodeKind sh:BlankNodeOrIRI ;
@@ -4495,121 +4777,73 @@ ns10:Dimensions a owl:Class,
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns10:yAxisLength ],
+            sh:path ns3:xAxisLength ],
         [ sh:class ns1:MeasureOfLength ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns10:zAxisLength ],
+            sh:path ns3:yAxisLength ],
         [ sh:class ns1:MeasureOfLength ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns10:xAxisLength ] .
+            sh:path ns3:zAxisLength ] .
 
-ns10:VirtualHardwareModelType a owl:Class ;
-    rdfs:comment "VirtualHardwareModelType sets the VirtualHardware Model Type."@en .
+ns3:VirtualHardwareModelType a owl:Class ;
+    rdfs:comment "Specifies the type of simulation model used to represent virtual hardware."@en .
 
-ns4:VexVulnAssessmentRelationship a owl:Class,
+ns5:VexVulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Abstract ancestor class for all VEX relationships."@en ;
-    rdfs:subClassOf ns4:VulnAssessmentRelationship ;
+    rdfs:subClassOf ns5:VulnAssessmentRelationship ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:statusNotes ],
-        [ sh:message "https://spdx.org/rdf/3.1/terms/Security/VexVulnAssessmentRelationship is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns4:VexVulnAssessmentRelationship ] ;
+            sh:path ns5:statusNotes ],
+        [ sh:message "https://spdx.org/rdf/3/terms/Security/VexVulnAssessmentRelationship is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns5:VexVulnAssessmentRelationship ] ;
             sh:path rdf:type ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:vexVersion ] .
+            sh:path ns5:vexVersion ] .
 
-ns7:CreateAction a owl:Class ;
+ns4:FileKindType a owl:Class ;
+    rdfs:comment "Enumeration of the different kinds of SPDX file."@en .
+
+ns9:CreateAction a owl:Class ;
     rdfs:comment "CreationAction represents an event of product creation."@en ;
     rdfs:subClassOf ns1:Action ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:message "https://spdx.org/rdf/3.1/terms/SupplyChain/CreateAction is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns7:CreateAction ] ;
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/SupplyChain/CreateAction is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns9:CreateAction ] ;
             sh:path rdf:type ] .
 
-ns7:ResponsibilityType a owl:Class ;
-    rdfs:comment "These categories help define sets Responsibility Type."@en .
+ns9:ResponsibilityType a owl:Class ;
+    rdfs:comment "Specifies the type of responsibility held over an asset, property, or entity."@en .
 
-ns7:State a owl:Class ;
+ns9:State a owl:Class ;
     rdfs:comment "A state is an instance that describes what a system, component, subsystem, process, or project has achieved at any given time."@en ;
     rdfs:subClassOf ns1:Artifact ;
     sh:nodeKind sh:IRI .
 
-ns7:UseProcess a owl:Class ;
+ns9:UseProcess a owl:Class ;
     rdfs:comment "Use Process defines actions used by elements."@en ;
     rdfs:subClassOf ns1:DefinedProcess ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:message "https://spdx.org/rdf/3.1/terms/SupplyChain/UseProcess is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns7:UseProcess ] ;
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/SupplyChain/UseProcess is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns9:UseProcess ] ;
             sh:path rdf:type ] .
 
-ns5:SafetyRiskAssessmentType a owl:Class ;
+ns7:SafetyRiskAssessmentType a owl:Class ;
     rdfs:comment "Safety risk level."@en .
 
 ns1:ContactPointRelationshipType a owl:Class ;
     rdfs:comment "Information about the type of contact point for `ContactPointRelationship`s."@en .
 
-ns1:DefinedType a owl:Class,
-        sh:NodeShape ;
-    rdfs:comment "The DefinedType class associates a specific type with its defined source."@en ;
-    sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:class ns1:Specification ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:definitionSource ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:typeFromSource ] .
-
 ns1:ProcessReadinessType a owl:Class ;
     rdfs:comment "The ProcessReadinessType is defined by the enumeration."@en .
-
-ns1:Relationship a owl:Class,
-        sh:NodeShape ;
-    rdfs:comment "Describes a relationship between one or more elements."@en ;
-    rdfs:subClassOf ns1:Element ;
-    sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:endTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:class ns1:Element ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:from ],
-        [ sh:class ns1:Element ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:to ],
-        [ sh:class ns1:RelationshipType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/affects> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/amendedBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/ancestorOf> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/availableFrom> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/configures> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/conformsTo> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/contains> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/coordinatedBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/copiedTo> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/createdBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/delegatedTo> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/dependsOn> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/descendantOf> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/describes> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/doesNotAffect> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/evaluatedOn> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/expandsTo> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/exploitCreatedBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/finetunedOn> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/fixedBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/fixedIn> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/follows> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/foundBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/generates> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasAddedFile> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasAssessmentFor> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasAssociatedVulnerability> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasConcludedLicense> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasContactPoint> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDataFile> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDeclaredLicense> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDeletedFile> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDependencyManifest> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDistributionArtifact> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDocumentation> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasDynamicLink> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasEvidence> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasExample> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasHost> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasInput> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasMetadata> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasOptionalComponent> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasOptionalDependency> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasOutput> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasPrerequisite> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasProvidedDependency> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasRequirement> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasResolution> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasSpecification> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasStaticLink> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasTest> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasTestCase> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/hasVariant> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/implementedBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/invokedBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/locatedAt> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/modifiedBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/other> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/packagedBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/patchedBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/pretrainedOn> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/providesSupportFor> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/performedBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/publishedBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/reportedBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/republishedBy> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/resolved> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/runsOn> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/serializedInArtifact> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/testedOn> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/tracedToDetail> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/trainedOn> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/underInvestigationFor> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/usesTool> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/validatedOn> <https://spdx.org/rdf/3.1/terms/Core/RelationshipType/verifiedBy> ) ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:relationshipType ],
-        [ sh:class ns1:RelationshipCompleteness ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/RelationshipCompleteness/incomplete> <https://spdx.org/rdf/3.1/terms/Core/RelationshipCompleteness/complete> <https://spdx.org/rdf/3.1/terms/Core/RelationshipCompleteness/noAssertion> ) ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:completeness ],
-        [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:startTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ] .
 
 ns1:SpecificationType a owl:Class ;
     rdfs:comment "A specification type defines the nature of a specification."@en .
@@ -4619,71 +4853,39 @@ ns1:comment a owl:DatatypeProperty ;
 Element."""@en ;
     rdfs:range xsd:string .
 
-ns3:ConfidentialityLevelType a owl:Class ;
+ns6:ConfidentialityLevelType a owl:Class ;
     rdfs:comment "Confidentiality level."@en .
 
-ns4:SsvcDecisionType a owl:Class ;
+ns5:SsvcDecisionType a owl:Class ;
     rdfs:comment "Specifies the SSVC decision type."@en .
 
 ns8:AuthenticationProtocolType a owl:Class ;
     rdfs:comment "Protocols which support authentication."@en .
 
-ns6:SoftwareArtifact a owl:Class,
-        sh:NodeShape ;
-    rdfs:comment "A distinct article or unit related to Software."@en ;
-    rdfs:subClassOf ns1:Artifact ;
-    sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns6:SoftwarePurpose ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/application> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/archive> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/bom> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/configuration> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/container> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/data> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/device> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/diskImage> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/deviceDriver> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/documentation> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/evidence> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/executable> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/file> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/filesystemImage> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/firmware> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/framework> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/install> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/library> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/manifest> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/model> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/module> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/operatingSystem> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/other> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/patch> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/platform> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/requirement> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/source> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/specification> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/test> ) ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns6:primaryPurpose ],
-        [ sh:class ns6:ContentIdentifier ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns6:contentIdentifier ],
-        [ sh:message "https://spdx.org/rdf/3.1/terms/Software/SoftwareArtifact is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns6:SoftwareArtifact ] ;
-            sh:path rdf:type ],
-        [ sh:class ns6:SoftwarePurpose ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/application> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/archive> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/bom> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/configuration> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/container> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/data> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/device> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/diskImage> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/deviceDriver> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/documentation> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/evidence> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/executable> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/file> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/filesystemImage> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/firmware> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/framework> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/install> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/library> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/manifest> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/model> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/module> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/operatingSystem> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/other> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/patch> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/platform> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/requirement> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/source> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/specification> <https://spdx.org/rdf/3.1/terms/Software/SoftwarePurpose/test> ) ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns6:additionalPurpose ],
-        [ sh:datatype xsd:nonNegativeInteger ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns6:artifactSize ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns6:copyrightText ],
-        [ sh:datatype xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns6:attributionText ] .
-
-ns7:CreateProcess a owl:Class ;
+ns9:CreateProcess a owl:Class ;
     rdfs:comment "The CreateProcess refers to the abstract process class that can be used to represent the process of creation of a product."@en ;
     rdfs:subClassOf ns1:DefinedProcess ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:message "https://spdx.org/rdf/3.1/terms/SupplyChain/CreateProcess is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns7:CreateProcess ] ;
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/SupplyChain/CreateProcess is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns9:CreateProcess ] ;
             sh:path rdf:type ] .
 
-ns5:EnergyConsumptionDescription a owl:Class,
+ns7:EnergyConsumptionDescription a owl:Class,
         sh:NodeShape ;
     rdfs:comment """The class that helps note down the quantity of energy consumption and the unit
 used for measurement."""@en ;
     sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:class ns5:EnergyUnitType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/AI/EnergyUnitType/kilowattHour> <https://spdx.org/rdf/3.1/terms/AI/EnergyUnitType/megajoule> <https://spdx.org/rdf/3.1/terms/AI/EnergyUnitType/other> ) ;
+    sh:property [ sh:class ns7:EnergyUnitType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/AI/EnergyUnitType/kilowattHour> <https://spdx.org/rdf/3/terms/AI/EnergyUnitType/megajoule> <https://spdx.org/rdf/3/terms/AI/EnergyUnitType/other> ) ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns5:energyUnit ],
+            sh:path ns7:energyUnit ],
         [ sh:datatype xsd:decimal ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns5:energyQuantity ] .
+            sh:path ns7:energyQuantity ] .
 
 ns1:Action a owl:Class,
         sh:NodeShape ;
@@ -4693,51 +4895,51 @@ ns1:Action a owl:Class,
     sh:property [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:actionStartTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:class ns1:DictionaryEntry ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:additionalInformation ],
-        [ sh:message "https://spdx.org/rdf/3.1/terms/Core/Action is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:path ns1:startTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:message "https://spdx.org/rdf/3/terms/Core/Action is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
             sh:not [ sh:hasValue ns1:Action ] ;
             sh:path rdf:type ],
         [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:actionEndTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+            sh:path ns1:endTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
         [ sh:class ns1:Location ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:actionLocation ] .
+            sh:path ns1:actionLocation ],
+        [ sh:class ns1:DictionaryEntry ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns1:additionalInformation ] .
 
 ns1:DefinedProcess a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Class that describes a process."@en ;
     rdfs:subClassOf ns1:Artifact ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:processVersion ],
-        [ sh:class ns1:ProcessReadinessType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/ProcessReadinessType/draft> <https://spdx.org/rdf/3.1/terms/Core/ProcessReadinessType/active> <https://spdx.org/rdf/3.1/terms/Core/ProcessReadinessType/obsolete> <https://spdx.org/rdf/3.1/terms/Core/ProcessReadinessType/other> ) ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:processReadiness ],
-        [ sh:message "https://spdx.org/rdf/3.1/terms/Core/DefinedProcess is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/Core/DefinedProcess is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
             sh:not [ sh:hasValue ns1:DefinedProcess ] ;
             sh:path rdf:type ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:processRationale ] .
+            sh:path ns1:rationale ],
+        [ sh:class ns1:ProcessReadinessType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/ProcessReadinessType/draft> <https://spdx.org/rdf/3/terms/Core/ProcessReadinessType/active> <https://spdx.org/rdf/3/terms/Core/ProcessReadinessType/obsoleted> <https://spdx.org/rdf/3/terms/Core/ProcessReadinessType/other> ) ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:processReadiness ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:version ] .
 
 ns1:IntegrityMethod a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Provides an independently reproducible mechanism that permits verification of a specific Element."@en ;
     sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:message "https://spdx.org/rdf/3.1/terms/Core/IntegrityMethod is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/Core/IntegrityMethod is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
             sh:not [ sh:hasValue ns1:IntegrityMethod ] ;
             sh:path rdf:type ],
         [ sh:datatype xsd:string ;
@@ -4750,47 +4952,101 @@ ns1:MeasureOfLength a owl:Class ;
     rdfs:subClassOf ns1:UnitOfMeasure ;
     sh:nodeKind sh:BlankNodeOrIRI .
 
-ns3:DatasetAvailabilityType a owl:Class ;
+ns1:Relationship a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "Describes a relationship between one or more elements."@en ;
+    rdfs:subClassOf ns1:Element ;
+    sh:nodeKind sh:IRI ;
+    sh:property [ sh:class ns1:Element ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:to ],
+        [ sh:class ns1:RelationshipCompleteness ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/RelationshipCompleteness/incomplete> <https://spdx.org/rdf/3/terms/Core/RelationshipCompleteness/complete> <https://spdx.org/rdf/3/terms/Core/RelationshipCompleteness/noAssertion> ) ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:completeness ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:startTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:class ns1:Element ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:from ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:endTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:class ns1:RelationshipType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/RelationshipType/affects> <https://spdx.org/rdf/3/terms/Core/RelationshipType/amendedBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/ancestorOf> <https://spdx.org/rdf/3/terms/Core/RelationshipType/assumes> <https://spdx.org/rdf/3/terms/Core/RelationshipType/availableFrom> <https://spdx.org/rdf/3/terms/Core/RelationshipType/configures> <https://spdx.org/rdf/3/terms/Core/RelationshipType/conformsTo> <https://spdx.org/rdf/3/terms/Core/RelationshipType/contains> <https://spdx.org/rdf/3/terms/Core/RelationshipType/coordinatedBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/copiedTo> <https://spdx.org/rdf/3/terms/Core/RelationshipType/createdBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/delegatedTo> <https://spdx.org/rdf/3/terms/Core/RelationshipType/dependsOn> <https://spdx.org/rdf/3/terms/Core/RelationshipType/descendantOf> <https://spdx.org/rdf/3/terms/Core/RelationshipType/describes> <https://spdx.org/rdf/3/terms/Core/RelationshipType/doesNotAffect> <https://spdx.org/rdf/3/terms/Core/RelationshipType/evaluatedOn> <https://spdx.org/rdf/3/terms/Core/RelationshipType/expandsTo> <https://spdx.org/rdf/3/terms/Core/RelationshipType/exploitCreatedBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/finetunedOn> <https://spdx.org/rdf/3/terms/Core/RelationshipType/fixedBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/fixedIn> <https://spdx.org/rdf/3/terms/Core/RelationshipType/follows> <https://spdx.org/rdf/3/terms/Core/RelationshipType/foundBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/generates> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasAddedFile> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasAssessmentFor> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasAssociatedVulnerability> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasConcludedLicense> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasContactPoint> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDataFile> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDeclaredLicense> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDeletedFile> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDependencyManifest> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDistributionArtifact> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDocumentation> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasDynamicLink> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasEvidence> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasExample> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasHost> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasInput> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasMetadata> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasOptionalComponent> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasOptionalDependency> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasOutput> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasPrerequisite> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasProvidedDependency> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasRequirement> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasResolution> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasRoleIn> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasSpecification> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasStaticLink> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasTest> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasTestCase> <https://spdx.org/rdf/3/terms/Core/RelationshipType/hasVariant> <https://spdx.org/rdf/3/terms/Core/RelationshipType/implementedBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/invokedBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/locatedAt> <https://spdx.org/rdf/3/terms/Core/RelationshipType/modifiedBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/other> <https://spdx.org/rdf/3/terms/Core/RelationshipType/packagedBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/patchedBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/performedBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/pretrainedOn> <https://spdx.org/rdf/3/terms/Core/RelationshipType/providesSupportFor> <https://spdx.org/rdf/3/terms/Core/RelationshipType/publishedBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/reportedBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/republishedBy> <https://spdx.org/rdf/3/terms/Core/RelationshipType/resolved> <https://spdx.org/rdf/3/terms/Core/RelationshipType/runsOn> <https://spdx.org/rdf/3/terms/Core/RelationshipType/serializedInArtifact> <https://spdx.org/rdf/3/terms/Core/RelationshipType/testedOn> <https://spdx.org/rdf/3/terms/Core/RelationshipType/tracedToDetail> <https://spdx.org/rdf/3/terms/Core/RelationshipType/trainedOn> <https://spdx.org/rdf/3/terms/Core/RelationshipType/underInvestigationFor> <https://spdx.org/rdf/3/terms/Core/RelationshipType/usesTool> <https://spdx.org/rdf/3/terms/Core/RelationshipType/validatedOn> <https://spdx.org/rdf/3/terms/Core/RelationshipType/verifiedBy> ) ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:relationshipType ] .
+
+ns1:RequirementStatusType a owl:Class ;
+    rdfs:comment "Provide an enumerated set of requirement statuses that can provide state to a requirement."@en .
+
+ns6:DatasetAvailabilityType a owl:Class ;
     rdfs:comment "Availability of dataset."@en .
 
 ns2:EvidenceType a owl:Class ;
     rdfs:comment "EvidenceType refers to categories of documented or observable proof used to verify compliance, qualification, or performance"@en .
 
-ns4:VexJustificationType a owl:Class ;
+ns5:VexJustificationType a owl:Class ;
     rdfs:comment "Specifies the VEX justification type."@en .
 
 ns1:CreationInfo a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Provides information about the creation of the Element."@en ;
     sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:datatype xsd:dateTimeStamp ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:comment ],
+        [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path ns1:created ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:comment ],
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
         [ sh:class ns1:Tool ;
             sh:nodeKind sh:IRI ;
             sh:path ns1:createdUsing ],
-        [ sh:class ns1:Agent ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:createdBy ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path ns1:specVersion ;
-            sh:pattern "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))?(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$" ] .
+            sh:pattern "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))?$" ],
+        [ sh:class ns1:Agent ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:createdBy ] .
 
-ns4:CvssSeverityType a owl:Class ;
+ns1:DefinedType a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "The DefinedType class associates a specific type with its defined source."@en ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:typeFromSource ],
+        [ sh:class ns1:Specification ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:definitionSource ] .
+
+ns5:CvssSeverityType a owl:Class ;
     rdfs:comment "Specifies the CVSS base, temporal, threat, or environmental severity type."@en .
 
-ns4:VulnAssessmentRelationship a owl:Class,
+ns5:VulnAssessmentRelationship a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Abstract ancestor class for all vulnerability assessments."@en ;
     rdfs:subClassOf ns1:Relationship ;
@@ -4798,68 +5054,41 @@ ns4:VulnAssessmentRelationship a owl:Class,
     sh:property [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns4:modifiedTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns4:publishedTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns4:withdrawnTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:class ns6:SoftwareArtifact ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns4:assessedElement ],
-        [ sh:message "https://spdx.org/rdf/3.1/terms/Security/VulnAssessmentRelationship is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns4:VulnAssessmentRelationship ] ;
-            sh:path rdf:type ],
+            sh:path ns5:publishedTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
         [ sh:class ns1:Agent ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:path ns1:suppliedBy ] .
+            sh:path ns1:suppliedBy ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns5:withdrawnTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:message "https://spdx.org/rdf/3/terms/Security/VulnAssessmentRelationship is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns5:VulnAssessmentRelationship ] ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns5:modifiedTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:class ns1:Artifact ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns5:assessedElement ] .
 
-ns6:SbomType a owl:Class ;
+ns4:SbomType a owl:Class ;
     rdfs:comment """Provides a set of values to be used to describe the common types of SBOMs that
 tools may create."""@en .
 
-ns7:UseAction a owl:Class ;
+ns9:UseAction a owl:Class ;
     rdfs:comment "The action of product use."@en ;
     rdfs:subClassOf ns1:Action ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:message "https://spdx.org/rdf/3.1/terms/SupplyChain/UseAction is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns7:UseAction ] ;
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/SupplyChain/UseAction is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns9:UseAction ] ;
             sh:path rdf:type ] .
-
-ns1:ExternalIdentifier a owl:Class,
-        sh:NodeShape ;
-    rdfs:comment "A reference to a resource identifier defined outside the scope of SPDX 3 content that uniquely identifies an Element."@en ;
-    sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:property [ sh:datatype xsd:anyURI ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:identifierLocator ],
-        [ sh:class ns1:ExternalIdentifierType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/cpe22> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/cpe23> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/cve> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/duns> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/email> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/evidenceUUID> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/gitoid> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/gln> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/glue> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/gtin> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/hsCodes> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/lei> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/other> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/packageUrl> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/phoneNumber> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/requirementUUID> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/securityOther> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/swhid> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/swid> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/urlScheme> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/verificationUUID> <https://spdx.org/rdf/3.1/terms/Core/ExternalIdentifierType/webpage> ) ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:externalIdentifierType ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:identifier ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:comment ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:issuingAuthority ] .
 
 ns1:IsoAutomationLevel a owl:Class ;
     rdfs:comment "Defines the level of automation a system possesses."@en .
@@ -4874,7 +5103,7 @@ or features of a product, process, or system."""@en ;
     rdfs:subClassOf ns1:Artifact ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:class ns1:SpecificationType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/SpecificationType/formalStandard> <https://spdx.org/rdf/3.1/terms/Core/SpecificationType/regulation> <https://spdx.org/rdf/3.1/terms/Core/SpecificationType/specification> <https://spdx.org/rdf/3.1/terms/Core/SpecificationType/other> ) ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/SpecificationType/formalStandard> <https://spdx.org/rdf/3/terms/Core/SpecificationType/regulation> <https://spdx.org/rdf/3/terms/Core/SpecificationType/specification> <https://spdx.org/rdf/3/terms/Core/SpecificationType/other> ) ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:path ns1:specType ] .
@@ -4885,29 +5114,70 @@ ns1:SupportType a owl:Class ;
 ns2:VerificationType a owl:Class ;
     rdfs:comment "Enumeration of verification types."@en .
 
+ns1:ExternalIdentifier a owl:Class,
+        sh:NodeShape ;
+    rdfs:comment "A reference to a resource identifier defined outside the scope of SPDX 3 content that uniquely identifies an Element."@en ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:issuingAuthority ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:comment ],
+        [ sh:class ns1:ExternalIdentifierType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/ark> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/bic> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/cpe22> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/cpe23> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/cve> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/doi> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/duns> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/ecli> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/eli> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/email> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/eori> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/evidenceUID> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/gitoid> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/gln> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/glue> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/gtin> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/hsCodes> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/iban> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/ibid> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/ibrn> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/isan> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/isbn> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/iscc> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/isci> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/isil> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/ismn> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/isni> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/isrc> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/issn> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/iswc> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/lei> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/lexid> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/nli> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/orcidid> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/other> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/packageUrl> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/phoneNumber> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/requirementUID> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/rorid> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/securityOther> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/swhid> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/swid> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/urlScheme> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/vatNumber> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/verificationUID> <https://spdx.org/rdf/3/terms/Core/ExternalIdentifierType/webpage> ) ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:externalIdentifierType ],
+        [ sh:datatype xsd:anyURI ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:identifierLocator ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:identifier ] .
+
+ns1:LifecycleScopeType a owl:Class ;
+    rdfs:comment "Provide an enumerated set of lifecycle phases that can provide context to relationships."@en .
+
+<https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo> a owl:Class ;
+    rdfs:comment "Abstract class representing a license combination consisting of one or more licenses."@en ;
+    rdfs:subClassOf ns1:Element ;
+    sh:nodeKind sh:IRI ;
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue <https://spdx.org/rdf/3/terms/SimpleLicensing/AnyLicenseInfo> ] ;
+            sh:path rdf:type ] .
+
 ns1:Artifact a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A distinct article or unit within the domain."@en ;
     rdfs:subClassOf ns1:Element ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:datatype xsd:dateTimeStamp ;
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/Core/Artifact is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns1:Artifact ] ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path ns1:builtTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:class ns1:SupportType ;
+            sh:in ( <https://spdx.org/rdf/3/terms/Core/SupportType/development> <https://spdx.org/rdf/3/terms/Core/SupportType/support> <https://spdx.org/rdf/3/terms/Core/SupportType/deployed> <https://spdx.org/rdf/3/terms/Core/SupportType/limitedSupport> <https://spdx.org/rdf/3/terms/Core/SupportType/endOfSupport> <https://spdx.org/rdf/3/terms/Core/SupportType/noSupport> <https://spdx.org/rdf/3/terms/Core/SupportType/noAssertion> ) ;
+            sh:nodeKind sh:IRI ;
+            sh:path ns1:supportLevel ],
+        [ sh:datatype xsd:dateTimeStamp ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:releaseTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
         [ sh:class ns1:Agent ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:path ns1:suppliedBy ],
-        [ sh:datatype xsd:dateTimeStamp ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:validUntilTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path ns1:intendedUse ],
         [ sh:class ns1:Agent ;
             sh:nodeKind sh:IRI ;
             sh:path ns1:originatedBy ],
@@ -4917,46 +5187,32 @@ ns1:Artifact a owl:Class,
         [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:releaseTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ],
-        [ sh:class ns1:SupportType ;
-            sh:in ( <https://spdx.org/rdf/3.1/terms/Core/SupportType/development> <https://spdx.org/rdf/3.1/terms/Core/SupportType/support> <https://spdx.org/rdf/3.1/terms/Core/SupportType/deployed> <https://spdx.org/rdf/3.1/terms/Core/SupportType/limitedSupport> <https://spdx.org/rdf/3.1/terms/Core/SupportType/endOfSupport> <https://spdx.org/rdf/3.1/terms/Core/SupportType/noSupport> <https://spdx.org/rdf/3.1/terms/Core/SupportType/noAssertion> ) ;
-            sh:nodeKind sh:IRI ;
-            sh:path ns1:supportLevel ],
-        [ sh:message "https://spdx.org/rdf/3.1/terms/Core/Artifact is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns1:Artifact ] ;
-            sh:path rdf:type ] .
+            sh:path ns1:validUntilTime ;
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:intendedUse ] .
 
-ns1:LifecycleScopeType a owl:Class ;
-    rdfs:comment "Provide an enumerated set of lifecycle phases that can provide context to relationships."@en .
-
-<https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo> a owl:Class ;
-    rdfs:comment "Abstract class representing a license combination consisting of one or more licenses."@en ;
-    rdfs:subClassOf ns1:Element ;
-    sh:nodeKind sh:IRI ;
-    sh:property [ sh:message "https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue <https://spdx.org/rdf/3.1/terms/SimpleLicensing/AnyLicenseInfo> ] ;
-            sh:path rdf:type ] .
+ns6:DatasetType a owl:Class ;
+    rdfs:comment "Enumeration of dataset types."@en .
 
 ns1:ProfileIdentifierType a owl:Class ;
-    rdfs:comment "Enumeration of the valid profiles."@en .
-
-ns3:DatasetType a owl:Class ;
-    rdfs:comment "Enumeration of dataset types."@en .
+    rdfs:comment "Enumeration of valid profile identifiers."@en .
 
 ns1:Location a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Location is used to define the location, address or coordinates of a place."@en ;
     rdfs:subClassOf ns1:Element ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:message "https://spdx.org/rdf/3.1/terms/Core/Location is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+    sh:property [ sh:message "https://spdx.org/rdf/3/terms/Core/Location is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
             sh:not [ sh:hasValue ns1:Location ] ;
             sh:path rdf:type ],
         [ sh:datatype xsd:dateTimeStamp ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path ns1:locationTime ;
-            sh:pattern "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$" ] .
+            sh:pattern "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|23:59:60)Z$" ] .
 
 ns1:DictionaryEntry a owl:Class,
         sh:NodeShape ;
@@ -4972,9 +5228,6 @@ ns1:DictionaryEntry a owl:Class,
             sh:nodeKind sh:Literal ;
             sh:path ns1:value ] .
 
-ns1:ExternalIdentifierType a owl:Class ;
-    rdfs:comment "Specifies the type of an external identifier."@en .
-
 ns1:HashAlgorithm a owl:Class ;
     rdfs:comment "A mathematical algorithm that maps data of arbitrary size to a bit string."@en .
 
@@ -4983,27 +5236,31 @@ ns1:Agent a owl:Class ;
     rdfs:subClassOf ns1:Element ;
     sh:nodeKind sh:IRI .
 
-ns6:SoftwarePurpose a owl:Class ;
+ns4:SoftwarePurpose a owl:Class ;
     rdfs:comment "Provides information about the primary purpose of an Element."@en .
 
 ns1:Element a owl:Class,
         sh:NodeShape ;
     rdfs:comment "Base domain class from which all other SPDX 3 domain classes derive."@en ;
     sh:nodeKind sh:IRI ;
-    sh:property [ sh:class ns1:ExternalRef ;
+    sh:property [ sh:class ns1:ExternalIdentifier ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:externalRef ],
-        [ sh:message "https://spdx.org/rdf/3.1/terms/Core/Element is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
-            sh:not [ sh:hasValue ns1:Element ] ;
-            sh:path rdf:type ],
+            sh:path ns1:externalIdentifier ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ns1:description ],
+        [ sh:class ns1:IntegrityMethod ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns1:verifiedUsing ],
         [ sh:class ns1:CreationInfo ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:path ns1:creationInfo ],
-        [ sh:class ns1:IntegrityMethod ;
+        [ sh:class ns1:ExternalRef ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:verifiedUsing ],
+            sh:path ns1:externalRef ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
@@ -5011,26 +5268,25 @@ ns1:Element a owl:Class,
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:comment ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
             sh:path ns1:name ],
-        [ sh:class ns1:ExternalIdentifier ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path ns1:externalIdentifier ],
+        [ sh:message "https://spdx.org/rdf/3/terms/Core/Element is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
+            sh:not [ sh:hasValue ns1:Element ] ;
+            sh:path rdf:type ],
+        [ sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path ns1:extension ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path ns1:description ],
+            sh:path ns1:comment ],
         [ sh:message "Class is known to not derive from Extension and cannot be used"@en ;
-            sh:not [ sh:or ( [ sh:class ns2:RequirementVerification ] [ sh:class ns2:EvidenceRelationship ] [ sh:class ns2:EvaluationResult ] [ sh:class ns4:SsvcVulnAssessmentRelationship ] [ sh:class ns4:CvssV2VulnAssessmentRelationship ] [ sh:class ns4:ExploitCatalogVulnAssessmentRelationship ] [ sh:class ns4:CvssV4VulnAssessmentRelationship ] [ sh:class ns4:VexAffectedVulnAssessmentRelationship ] [ sh:class ns4:VexNotAffectedVulnAssessmentRelationship ] [ sh:class ns4:CvssV3VulnAssessmentRelationship ] [ sh:class ns4:Vulnerability ] [ sh:class ns4:VexUnderInvestigationVulnAssessmentRelationship ] [ sh:class ns4:EpssVulnAssessmentRelationship ] [ sh:class ns4:VexFixedVulnAssessmentRelationship ] [ sh:class ns1:NamespaceMap ] [ sh:class ns1:LifecycleScopedRelationship ] [ sh:class ns1:ElementMap ] [ sh:class ns1:SupportRelationship ] [ sh:class ns1:Hash ] [ sh:class ns1:Agent ] [ sh:class ns1:MeasureOfLength ] [ sh:class ns1:CreationInfo ] [ sh:class ns1:ContactPointRelationship ] [ sh:class ns1:ExternalRef ] [ sh:class ns1:Specification ] [ sh:class ns1:Bom ] [ sh:class ns1:IndividualElement ] [ sh:class ns1:Relationship ] [ sh:class ns1:UnitOfMeasure ] [ sh:class ns1:PositiveIntegerRange ] [ sh:class ns1:DictionaryEntry ] [ sh:class ns1:ExternalMap ] [ sh:class ns1:Annotation ] [ sh:class ns1:DefinedType ] [ sh:class ns1:SpdxDocument ] [ sh:class ns1:Person ] [ sh:class ns1:Organization ] [ sh:class ns1:MeasureOfMass ] [ sh:class ns1:Bundle ] [ sh:class ns1:Tool ] [ sh:class ns1:Requirement ] [ sh:class ns1:ExternalIdentifier ] [ sh:class ns1:SoftwareAgent ] [ sh:class ns1:PackageVerificationCode ] [ sh:class ns1:PhysicalLocation ] [ sh:class ns1:Regulation ] [ sh:class ns5:AIPackage ] [ sh:class ns5:EnergyConsumptionDescription ] [ sh:class ns5:EnergyConsumption ] [ sh:class <https://spdx.org/rdf/3.1/terms/Build/Build> ] [ sh:class ns3:DatasetPackage ] [ sh:class ns9:CustomLicense ] [ sh:class ns9:OrLaterOperator ] [ sh:class ns9:ListedLicense ] [ sh:class ns9:DisjunctiveLicenseSet ] [ sh:class ns9:ListedLicenseException ] [ sh:class ns9:WithAdditionOperator ] [ sh:class ns9:IndividualLicensingInfo ] [ sh:class ns9:CustomLicenseAddition ] [ sh:class ns9:ConjunctiveLicenseSet ] [ sh:class <https://spdx.org/rdf/3.1/terms/SimpleLicensing/LicenseExpression> ] [ sh:class <https://spdx.org/rdf/3.1/terms/SimpleLicensing/SimpleLicensingText> ] [ sh:class <https://spdx.org/rdf/3.1/terms/Extension/CdxPropertyEntry> ] [ sh:class <https://spdx.org/rdf/3.1/terms/Operations/Project> ] [ sh:class <https://spdx.org/rdf/3.1/terms/Operations/ExportControlClassificationAssessment> ] [ sh:class <https://spdx.org/rdf/3.1/terms/Operations/ExportControlClassification> ] [ sh:class ns7:StateAction ] [ sh:class ns7:State ] [ sh:class ns7:AssemblyAction ] [ sh:class ns7:BoundaryDefinitionProcess ] [ sh:class ns7:DestroyProcess ] [ sh:class ns7:ResponsibilityChangeAction ] [ sh:class ns7:PlanAction ] [ sh:class ns7:DestroyAction ] [ sh:class ns7:ChangeAction ] [ sh:class ns7:TransportProcess ] [ sh:class ns7:ResolutionAction ] [ sh:class ns7:TestProcess ] [ sh:class ns7:DefinedStateProcess ] [ sh:class ns7:StorageProcess ] [ sh:class ns7:StorageAction ] [ sh:class ns7:PlanProcess ] [ sh:class ns7:ReproduceAction ] [ sh:class ns7:ReproduceProcess ] [ sh:class ns7:BoundaryCrossingAction ] [ sh:class ns7:InspectionProcess ] [ sh:class ns7:InstantiateVirtualHardwareProcess ] [ sh:class ns7:AssemblyProcess ] [ sh:class ns7:ManufactureProcess ] [ sh:class ns7:BoundaryDefinitionAction ] [ sh:class ns7:OutOfSpecAction ] [ sh:class ns7:ResponsibilityChangeProcess ] [ sh:class ns7:HarvestProcess ] [ sh:class ns7:InspectionAction ] [ sh:class ns7:ChangeProcess ] [ sh:class ns7:ManufactureAction ] [ sh:class ns7:TransportAction ] [ sh:class ns7:HarvestAction ] [ sh:class ns7:TestAction ] [ sh:class ns8:SoftwareService ] [ sh:class ns6:Package ] [ sh:class ns6:File ] [ sh:class ns6:Sbom ] [ sh:class ns6:Snippet ] [ sh:class ns6:ContentIdentifier ] [ sh:class ns10:VirtualHardware ] [ sh:class ns10:Dimensions ] [ sh:class ns10:ProductSpecification ] [ sh:class ns10:PhysicalHardware ] [ sh:class ns10:BulkHardware ] ) ] ;
-            sh:path ns1:extension ],
-        [ sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:not [ sh:or ( [ sh:class <https://spdx.org/rdf/3/terms/Build/Build> ] [ sh:class ns9:PlanProcess ] [ sh:class ns9:DestroyProcess ] [ sh:class ns9:ChangeProcess ] [ sh:class ns9:ChangeAction ] [ sh:class ns9:DefinedStateProcess ] [ sh:class ns9:TransportProcess ] [ sh:class ns9:BoundaryDefinitionProcess ] [ sh:class ns9:DestroyAction ] [ sh:class ns9:BoundaryDefinitionAction ] [ sh:class ns9:ResolutionAction ] [ sh:class ns9:TestAction ] [ sh:class ns9:ReproduceProcess ] [ sh:class ns9:State ] [ sh:class ns9:PlanAction ] [ sh:class ns9:AssemblyProcess ] [ sh:class ns9:InstantiateVirtualHardwareProcess ] [ sh:class ns9:StorageAction ] [ sh:class ns9:ResponsibilityChangeProcess ] [ sh:class ns9:TestProcess ] [ sh:class ns9:OutOfSpecAction ] [ sh:class ns9:ReproduceAction ] [ sh:class ns9:InspectionAction ] [ sh:class ns9:ManufactureProcess ] [ sh:class ns9:InspectionProcess ] [ sh:class ns9:ResponsibilityChangeAction ] [ sh:class ns9:HarvestAction ] [ sh:class ns9:ManufactureAction ] [ sh:class ns9:TransportAction ] [ sh:class ns9:AssemblyAction ] [ sh:class ns9:BoundaryCrossingAction ] [ sh:class ns9:HarvestProcess ] [ sh:class ns9:StorageProcess ] [ sh:class ns9:StateAction ] [ sh:class <https://spdx.org/rdf/3/terms/SimpleLicensing/SimpleLicensingText> ] [ sh:class <https://spdx.org/rdf/3/terms/SimpleLicensing/LicenseExpression> ] [ sh:class ns6:DatasetPackage ] [ sh:class ns7:AIPackage ] [ sh:class ns7:EnergyConsumptionDescription ] [ sh:class ns7:EnergyConsumption ] [ sh:class ns10:CustomLicenseAddition ] [ sh:class ns10:WithAdditionOperator ] [ sh:class ns10:ListedLicenseException ] [ sh:class ns10:IndividualLicensingInfo ] [ sh:class ns10:OrLaterOperator ] [ sh:class ns10:ListedLicense ] [ sh:class ns10:ConjunctiveLicenseSet ] [ sh:class ns10:DisjunctiveLicenseSet ] [ sh:class ns10:CustomLicense ] [ sh:class <https://spdx.org/rdf/3/terms/Extension/CdxPropertyEntry> ] [ sh:class ns8:SoftwareService ] [ sh:class ns1:Regulation ] [ sh:class ns1:CreationInfo ] [ sh:class ns1:DefinedType ] [ sh:class ns1:ElementMap ] [ sh:class ns1:Annotation ] [ sh:class ns1:ExternalRef ] [ sh:class ns1:RoleRelationship ] [ sh:class ns1:NamespaceMap ] [ sh:class ns1:LifecycleScopedRelationship ] [ sh:class ns1:IndividualElement ] [ sh:class ns1:Relationship ] [ sh:class ns1:Bundle ] [ sh:class ns1:DictionaryEntry ] [ sh:class ns1:PositiveIntegerRange ] [ sh:class ns1:Bom ] [ sh:class ns1:PhysicalLocation ] [ sh:class ns1:ExternalMap ] [ sh:class ns1:Agent ] [ sh:class ns1:Hash ] [ sh:class ns1:ExternalIdentifier ] [ sh:class ns1:MeasureOfLength ] [ sh:class ns1:PackageVerificationCode ] [ sh:class ns1:Specification ] [ sh:class ns1:Organization ] [ sh:class ns1:SoftwareAgent ] [ sh:class ns1:Requirement ] [ sh:class ns1:Tool ] [ sh:class ns1:MeasureOfMass ] [ sh:class ns1:ContactPointRelationship ] [ sh:class ns1:SpdxDocument ] [ sh:class ns1:UnitOfMeasure ] [ sh:class ns1:SupportRelationship ] [ sh:class ns1:Person ] [ sh:class ns1:Role ] [ sh:class ns5:CvssV2VulnAssessmentRelationship ] [ sh:class ns5:EpssVulnAssessmentRelationship ] [ sh:class ns5:VexFixedVulnAssessmentRelationship ] [ sh:class ns5:CvssV4VulnAssessmentRelationship ] [ sh:class ns5:VexAffectedVulnAssessmentRelationship ] [ sh:class ns5:VexUnderInvestigationVulnAssessmentRelationship ] [ sh:class ns5:ExploitCatalogVulnAssessmentRelationship ] [ sh:class ns5:Vulnerability ] [ sh:class ns5:CvssV3VulnAssessmentRelationship ] [ sh:class ns5:VexNotAffectedVulnAssessmentRelationship ] [ sh:class ns5:SsvcVulnAssessmentRelationship ] [ sh:class ns4:File ] [ sh:class ns4:ContentIdentifier ] [ sh:class ns4:Snippet ] [ sh:class ns4:Package ] [ sh:class ns4:Sbom ] [ sh:class <https://spdx.org/rdf/3/terms/Operations/ExportControlClassification> ] [ sh:class <https://spdx.org/rdf/3/terms/Operations/ExportControlClassificationAssessment> ] [ sh:class <https://spdx.org/rdf/3/terms/Operations/Project> ] [ sh:class ns3:Dimensions ] [ sh:class ns3:ProductSpecification ] [ sh:class ns3:VirtualHardware ] [ sh:class ns3:BulkHardware ] [ sh:class ns3:PhysicalHardware ] [ sh:class ns2:RequirementVerification ] [ sh:class ns2:EvidenceRelationship ] [ sh:class ns2:Assumption ] [ sh:class ns2:EvaluationResult ] ) ] ;
             sh:path ns1:extension ] .
 
+ns1:ExternalIdentifierType a owl:Class ;
+    rdfs:comment "Specifies the type of an external identifier."@en .
+
 ns1:ExternalRefType a owl:Class ;
-    rdfs:comment "Specifies the type of an external reference."@en .
+    rdfs:comment "The type of external reference."@en .
 
 ns1:RelationshipType a owl:Class ;
     rdfs:comment "Information about the relationship between two Elements."@en .


### PR DESCRIPTION
Change how the spec versions are recognized and generated.  These changes are necessary since we no longer include the minor version in the IRI strings.